### PR TITLE
fixes #96

### DIFF
--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -136,7 +136,7 @@ export class SubmEditComponent implements OnInit, OnDestroy {
             return;
         }
 
-        this.submService.submitSubmission(this.wrap())
+        this.submService.submitSubmission(this.wrap({ignoreEmptySections: true}))
             .subscribe(
                 resp => {
                     console.log('submitted', resp);
@@ -191,9 +191,10 @@ export class SubmEditComponent implements OnInit, OnDestroy {
         bsModalRef.content.status = resp.status;
     }
 
-    private wrap(): any {
+    private wrap(opts?: { ignoreEmptySections: boolean }): any {
         const w = Object.assign({}, this.wrappedSubm);
-        w.data = PageTab.fromSubmission(this.subm);
+        const ignoreEmptySections = opts !== undefined ? opts.ignoreEmptySections === true : undefined;
+        w.data = PageTab.fromSubmission(this.subm, ignoreEmptySections);
         return w;
     }
 

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -1,5 +1,5 @@
 export const DefaultTemplate = {
-    'name': 'DeafultTemplate',
+    'name': 'DefaultTemplate',
     'sectionType': {
         'name': 'Study',
         'required': true,

--- a/src/app/submission/shared/pagetab.model.spec.ts
+++ b/src/app/submission/shared/pagetab.model.spec.ts
@@ -211,10 +211,10 @@ describe('PageTab', () => {
         const pt = PageTab.fromSubmission(subm);
 
         expect(pt.type).toBe('Submission');
-        expect(pt.accno).toEqual('');
+        expect(pt.accno).toBe('');
         expect(pt.section).toBeDefined();
         expect(pt.section.type).toBe('Study');
-        expect(pt.section.accno).toBeUndefined();
+        expect(pt.section.accno).toBe('');
         expect(pt.section.attributes).toBeDefined();
         expect(pt.section.attributes.length).toBe(secType.fieldTypes.length);
 

--- a/src/app/submission/shared/pagetab.model.spec.ts
+++ b/src/app/submission/shared/pagetab.model.spec.ts
@@ -1,6 +1,7 @@
 import {pageTabSample1} from './pagetab.samples';
 import {PageTab} from './pagetab.model';
 import {SubmissionType} from './submission-type.model';
+import {Submission} from "./submission.model";
 
 describe('PageTab', () => {
     it('can have undefined root section', () => {
@@ -226,5 +227,102 @@ describe('PageTab', () => {
         const s = pt.section.subsections[0];
         expect(s.type).toBe('Author');
         expect(s.attributes).toBeUndefined(); // all values are empty
+    });
+
+    it('does not ignore empty sections by default', () => {
+        const submType = SubmissionType.fromTemplate(
+            {
+                name: 'Test',
+                sectionType: {
+                    name: 'Study'
+                }
+            });
+        const subm = new Submission(submType,
+            {
+                accno: '123',
+                tags: [],
+                accessTags: [],
+                section: {
+                    type: 'Study',
+                    accno: '321',
+                    tags: [],
+                    accessTags: [],
+                    attributes: [],
+                    features: [{
+                        type: 'EmptyFeature',
+                        entries: []
+                    }],
+                    sections: [{
+                        type: 'EmptySection',
+                        accno: '1',
+                        tags: [],
+                        accessTags: [],
+                        attributes: [],
+                        features: [],
+                        sections: []
+                    }]
+                }
+            });
+
+        expect(subm.root.features.length).toEqual(1);
+        expect(subm.root.sections.length).toEqual(1);
+
+        const pt = PageTab.fromSubmission(subm);
+        expect(pt.section.subsections.length).toEqual(1); // empty features are not saved for now
+
+        const subm2 = new PageTab(pt).toSubmission(submType);
+
+        expect(subm2.root.features.length).toEqual(0);
+        expect(subm2.root.sections.length).toEqual(1);
+    });
+
+    it('does ignore empty sections if specified', () => {
+        const submType = SubmissionType.fromTemplate(
+            {
+                name: 'Test',
+                sectionType: {
+                    name: 'Study'
+                }
+            });
+        const subm = new Submission(submType,
+            {
+                accno: '123',
+                tags: [],
+                accessTags: [],
+                section: {
+                    type: 'Study',
+                    accno: '321',
+                    tags: [],
+                    accessTags: [],
+                    attributes: [{
+                        name: 'Attr',
+                        value: 'Value'
+                    }],
+                    features: [{
+                        type: 'EmptyFeature',
+                        entries: []
+                    }],
+                    sections: [{
+                        type: 'EmptySection',
+                        accno: '1',
+                        tags: [],
+                        accessTags: [],
+                        attributes: [],
+                        features: [],
+                        sections: []
+                    }]
+                }
+            });
+
+        expect(subm.root.features.length).toEqual(1);
+        expect(subm.root.sections.length).toEqual(1);
+
+        const pt = PageTab.fromSubmission(subm, true);
+        expect(pt.section.subsections).toBeUndefined();
+
+        const subm2 = new PageTab(pt).toSubmission(submType);
+
+        expect(subm2.root.features.length).toEqual(0);
+        expect(subm2.root.sections.length).toEqual(0);
     });
 });

--- a/src/app/submission/shared/pagetab.model.ts
+++ b/src/app/submission/shared/pagetab.model.ts
@@ -106,6 +106,7 @@ class PtSection extends PtEntry implements SectionData {
             .keys(featureMap)
             .filter(k => k !== HiddenFeature.type)
             .map(k => new PtFeature(k, featureMap[k]));
+
         if (obj.files !== undefined) {
             features.push(PtFeature.file(obj.files));
         }
@@ -177,7 +178,7 @@ export class PageTab implements SubmissionData {
         }
 
         if (links.length === 0 && files.length === 0 && subsections.length === 0) {
-            subsections.push(PageTab.fromFeature(HiddenFeature));
+            subsections = subsections.concat(PageTab.fromFeature(HiddenFeature));
         }
 
         const pts: any = {

--- a/src/app/submission/shared/pagetab.model.ts
+++ b/src/app/submission/shared/pagetab.model.ts
@@ -1,8 +1,6 @@
 import {
     AttributesData,
-    Feature,
     FeatureData,
-    Section,
     SectionData,
     Submission,
     SubmissionData
@@ -11,6 +9,20 @@ import {SubmissionType} from './submission-type.model';
 import {convertAuthorsToContacts, convertContactsToAuthors} from './pagetab-authors.utils';
 import {flattenDoubleArrays} from './pagetab-doublearrays.utils';
 import {copyAttributes} from './pagetab-attributes.utils';
+
+const HiddenFeature = {
+    type: '__HIDDEN__',
+    entries: [{
+        attributes: [{
+            name: '__NAME__',
+            value: '__VALUE__'
+        }]
+    }]
+} as FeatureData;
+
+const isEmptyArray = function (v) {
+    return v === undefined || v.length === 0
+};
 
 class PtEntry implements AttributesData {
     readonly attributes: { name: string, value: string }[];
@@ -69,10 +81,10 @@ class PtSection extends PtEntry implements SectionData {
     constructor(obj: any) {
         super(obj);
 
-        const isFeature = (s: any) => {
-            return s.subsections === undefined &&
-                s.files === undefined &&
-                s.links === undefined;
+        const isFeature = function (s: any) {
+            return isEmptyArray(s.subsections) &&
+                isEmptyArray(s.files) &&
+                isEmptyArray(s.links);
         };
 
         this.type = obj.type;
@@ -92,6 +104,7 @@ class PtSection extends PtEntry implements SectionData {
 
         const features = Object
             .keys(featureMap)
+            .filter(k => k !== HiddenFeature.type)
             .map(k => new PtFeature(k, featureMap[k]));
         if (obj.files !== undefined) {
             features.push(PtFeature.file(obj.files));
@@ -113,14 +126,15 @@ export class PageTab implements SubmissionData {
     readonly tags: any[];
     readonly accessTags: string[];
 
-    static fromSubmission(subm: Submission): any {
+    // ignoreEmptySections means that empty sections (and features) will not be included into PageTab
+    static fromSubmission(subm: Submission, ignoreEmptySections = false): any {
         const pt: any = {
             type: subm.type.name,
             accno: subm.accno,
             tags: subm.tags.tags,
             accessTags: subm.tags.accessTags
         };
-        pt.section = PageTab.fromSection(subm.root);
+        pt.section = PageTab.fromSection(subm.root.data, ignoreEmptySections);
         return convertContactsToAuthors(pt);
     }
 
@@ -129,74 +143,81 @@ export class PageTab implements SubmissionData {
         return PageTab.fromSubmission(pt.toSubmission(SubmissionType.createDefault()));
     }
 
-    private static fromSection(sec: Section): any {
-        const pts: any = {
-            type: sec.type.name,
-            tags: sec.tags.tags,
-            accessTags: sec.tags.accessTags
-        };
-
-        if (sec.accno) {
-            pts.accno = sec.accno;
-        }
-
-        let attributes = [];
-        if (sec.fields.length > 0) {
-            attributes = attributes.concat(sec.fields.list().map(fld => ({
-                name: fld.name,
-                value: fld.value
-            })));
-        }
-
-        if (sec.annotations.size() > 0) {
-            attributes.concat(PageTab.fromAnnotations(sec.annotations));
-        }
-
-        if (attributes.length > 0) {
-            pts.attributes = attributes;
-        }
-
+    private static fromSection(sd: SectionData, ignoreEmptySections: boolean): any {
         let subsections = [];
+        let files = [];
+        let links = [];
 
-        sec.features.list().filter(f => f.size() > 0).forEach(f => {
-            if (f.type.name === 'File') {
-                pts.files = PageTab.fromFileOrLinkFeature(f, 'file');
-            } else if (f.type.name === 'Link') {
-                pts.links = PageTab.fromFileOrLinkFeature(f, 'url');
-            } else {
-                subsections = subsections.concat(PageTab.fromFeature(f));
-            }
-        });
+        sd.features
+            .forEach(fd => {
+                if (fd.type === 'File') {
+                    files = PageTab.fromFileOrLinkFeature(fd, 'file');
+                } else if (fd.type === 'Link') {
+                    links = PageTab.fromFileOrLinkFeature(fd, 'url');
+                } else {
+                    subsections = subsections.concat(PageTab.fromFeature(fd));
+                }
+            });
 
         subsections = subsections.concat(
-            sec.sections.list().map(s => PageTab.fromSection(s))
-        );
+            sd.sections
+                .map(s => PageTab.fromSection(s, ignoreEmptySections))
+                .filter(s => s !== undefined));
+
+        if (ignoreEmptySections) {
+            subsections = subsections.filter(sub =>
+                !isEmptyArray(sub.attributes)
+                || !isEmptyArray(sub.files)
+                || !isEmptyArray(sub.links)
+                || !isEmptyArray(sub.subsections)
+            );
+            if (subsections.length === 0) {
+                return;
+            }
+        }
+
+        if (links.length === 0 && files.length === 0 && subsections.length === 0) {
+            subsections.push(PageTab.fromFeature(HiddenFeature));
+        }
+
+        const pts: any = {
+            type: sd.type,
+            accno: sd.accno,
+            tags: sd.tags,
+            accessTags: sd.accessTags
+        };
+
+        if (!isEmptyArray(sd.attributes)) {
+            pts.attributes = sd.attributes;
+        }
+
+        if (files.length > 0) {
+            pts.files = files;
+        }
+
+        if (links.length > 0) {
+            pts.links = links;
+        }
 
         if (subsections.length > 0) {
             pts.subsections = subsections;
         }
+
         return pts;
     }
 
-    private static fromAnnotations(f: Feature): any[] {
-        return PageTab.fromFeature(f)[0].attributes;
-    }
-
-    private static fromFeature(f: Feature): any[] {
-        return f.rows.map(row => (
+    private static fromFeature(fd: FeatureData): any[] {
+        return fd.entries.map(entry => (
             {
-                type: f.type.name,
-                attributes: f.columns.map(c => ({
-                    name: c.name,
-                    value: row.valueFor(c.id).value
-                }))
+                type: fd.type,
+                attributes: entry.attributes
             }));
     }
 
-    private static fromFileOrLinkFeature(feature: Feature, name: string): any[] {
+    private static fromFileOrLinkFeature(fd: FeatureData, name: string): any[] {
         const isNamedAttr = (a) => (a.name.toLowerCase() === name);
 
-        return PageTab.fromFeature(feature).map(f => {
+        return PageTab.fromFeature(fd).map(f => {
             const other = f.attributes.filter(!isNamedAttr);
             const ff: any = {type: f.type};
             ff[name] = (f.attributes.find(isNamedAttr) || {value: ''}).value || '';

--- a/src/app/submission/shared/pagetab.model.ts
+++ b/src/app/submission/shared/pagetab.model.ts
@@ -172,12 +172,10 @@ export class PageTab implements SubmissionData {
                 || !isEmptyArray(sub.links)
                 || !isEmptyArray(sub.subsections)
             );
-            if (subsections.length === 0) {
+            if (subsections.length === 0 && isEmptyArray(sd.attributes)) {
                 return;
             }
-        }
-
-        if (links.length === 0 && files.length === 0 && subsections.length === 0) {
+        } else if (links.length === 0 && files.length === 0 && subsections.length === 0) {
             subsections = subsections.concat(PageTab.fromFeature(HiddenFeature));
         }
 
@@ -192,15 +190,15 @@ export class PageTab implements SubmissionData {
             pts.attributes = sd.attributes;
         }
 
-        if (files.length > 0) {
+        if (!isEmptyArray(files)) {
             pts.files = files;
         }
 
-        if (links.length > 0) {
+        if (!isEmptyArray(links)) {
             pts.links = links;
         }
 
-        if (subsections.length > 0) {
+        if (!isEmptyArray(subsections)) {
             pts.subsections = subsections;
         }
 

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -317,6 +317,18 @@ export class Feature extends HasUpdates<UpdateEvent> {
         return this._columns.list();
     }
 
+    get data(): FeatureData {
+        const entries = this.rows.map(r => {
+            return {
+                attributes: this.columns.map(c => ({name: c.name, value: r.valueFor(c.id).value}))
+            }
+        });
+        return {
+            type: this.type.name,
+            entries: entries
+        }
+    }
+
     rowSize(): number {
         return this._rows.size();
     }
@@ -572,6 +584,24 @@ export class Section extends HasUpdates<UpdateEvent> {
         this.type.name = name;
         if (this.type.name === name) {
             this.notify(new UpdateEvent('type', name));
+        }
+    }
+
+    get data(): SectionData {
+        let attrs = [];
+        const annotations = this.annotations.data.entries;
+        if (annotations.length > 0) {
+            attrs = attrs.concat(annotations[0].attributes);
+        }
+        attrs = attrs.concat(this.fields.list().map(f => ({name: f.name, value: f.value})));
+        return {
+            tags: this.tags.tags,
+            accessTags: this.tags.accessTags,
+            type: this.type.name,
+            accno: this.accno,
+            attributes: attrs,
+            features: this.features.list().map(f => f.data),
+            sections: this.sections.list().map(s => s.data)
         }
     }
 


### PR DESCRIPTION
When submission is saved the empty sections are preserved now.. however empty features are not (it's not so critical actually). I think my way of preserving empty sections is a bit of a hack over PageTab format and I don't want to do the same hack for features.. there should be a better way to fix this if we allow comments or meta info in the PageTab... 