### PR TITLE
Fixes files/links issue by taking the location attribute outside the …

### DIFF
--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -4,9 +4,7 @@
     <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" (click)="toggleCollapsed()">
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
+                <i class="fa fa-bars" aria-hidden="true"></i>
             </button>
             <a  class="navbar-brand"
                 routerLink="/submissions">


### PR DESCRIPTION
…attributes array when converting to PageTab. 
Apparently, the proxy expects a "file" or "url" property at that position. It also expects link sections to have no "type" property at the root level. Hence its removal.
Took the opportunity to replace the the navicon with its corresponding font-awesome glyph.