### PR TITLE
Improves routing, implements sent submissions viewing and fixes various UX issues

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -33,11 +33,43 @@ const appRoutes: Routes = [
     {path: 'password_reset_request', component: PasswordResetReqComponent},
     {path: 'password_reset/:key', component: PasswordResetComponent},
     {path: 'resend_activation_link', component: ActivationLinkReqComponent},
-    {path: 'submissions', component: SubmListComponent, canActivate: [AuthGuard]},
-    {path: 'submissions/direct_upload', component: DirectSubmitComponent, canActivate: [AuthGuard]},
-    {path: 'submissions/:accno', component: SubmEditComponent, canActivate: [AuthGuard]},
-    {path: 'view/:accno', component: SubmViewComponent, canActivate: [AuthGuard]},
-    {path: 'files', component: FileListComponent, canActivate: [AuthGuard]}
+    {
+        path: 'submissions',
+        component: SubmListComponent,
+        data: {reuse: true},
+        canActivate: [AuthGuard]
+    },
+    {
+        path: 'submissions/sent',
+        component: SubmListComponent,
+        data: {isSent: true, reuse: true},
+        canActivate: [AuthGuard]},
+    {
+        path: 'submissions/direct_upload',
+        component: DirectSubmitComponent,
+        canActivate: [AuthGuard]
+    },
+    {
+        path: 'submissions/edit/:accno',
+        component: SubmEditComponent,
+        canActivate: [AuthGuard]
+    },
+    {
+        path: 'submissions/new/:accno',
+        component: SubmEditComponent,
+        data: {isNew: true},
+        canActivate: [AuthGuard]
+    },
+    {
+        path: 'submissions/:accno',
+        component: SubmViewComponent,
+        canActivate: [AuthGuard]
+    },
+    {
+        path: 'files',
+        component: FileListComponent,
+        canActivate: [AuthGuard]
+    }
 ];
 
 @NgModule({

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -28,6 +28,10 @@ export class AppConfig {
         return this.config.APP_PROD;
     }
 
+    get tabletBreak(): number {
+        return this.config.APP_TABLET_BREAKPOINT;
+    }
+
     // Promise is required here
     load(): Promise<any> {
         let req: Observable<any> = this.http.get('./config.json');

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -16,12 +16,13 @@ export class AuthGuard implements CanActivate {
     }
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-        if (!this.userSession.isAnonymous()) {
+        if (this.userSession.isAnonymous()) {
+            this.router.navigate(['/signin']);
+            return false;
+        } else {
             return true;
         }
-        //TODO this.authService.redirectUrl = state.url;
 
-        this.router.navigate(['/signin']);
-        return false;
+        //TODO this.authService.redirectUrl = state.url;
     }
 }

--- a/src/app/auth/signin/signin.component.html
+++ b/src/app/auth/signin/signin.component.html
@@ -2,7 +2,7 @@
     <container-md>
         <div class="auth-content">
             <div class="alert" [ngClass]="{'alert-danger': error, 'invisible': !error}">
-                {{error ? error.message.replace('FAIL', '') + '. Please check your email and password and try again.' : '&nbsp;'}}
+                {{error ? error.message.replace('FAIL', '') + '. Please check your credentials and try again.' : '&nbsp;'}}
             </div>
             <h3>Welcome</h3>
             <p>

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -27,7 +27,6 @@
                         Register
                     </button>
                 </li>
-
                 <li *ngIf="!userLoggedIn && !userLoggingIn">
                     <button class="btn navbar-btn"
                             routerLink="/signin"

--- a/src/app/file/file-list.component.ts
+++ b/src/app/file/file-list.component.ts
@@ -26,6 +26,7 @@ import {Path} from './path';
 import * as _ from 'lodash';
 
 import 'rxjs/add/operator/filter';
+import {AppConfig} from "../app.config";
 
 @Component({
     selector: 'file-actions-cell',
@@ -157,7 +158,12 @@ export class FileListComponent implements OnInit, OnDestroy {
 
     constructor(private fileService: FileService,
                 private fileUploadService: FileUploadService,
-                private route: ActivatedRoute) {
+                private route: ActivatedRoute,
+                private appConfig: AppConfig) {
+
+        //Initally collapses the sidebar for tablet-sized screens
+        this.sideBarCollapsed = window.innerWidth < this.appConfig.tabletBreak;
+
         this.gridOptions = <GridOptions>{
             onGridReady: () => {
                 this.gridOptions.api.sizeColumnsToFit();

--- a/src/app/shared/inline-edit.component.css
+++ b/src/app/shared/inline-edit.component.css
@@ -1,44 +1,33 @@
-/* Makes sure container is not outgrown by input when displayed */
-.inline-edit-wrapper {
-    height: 2.284em
+/* Makes the control appear as standard text, even when not on read-only mode */
+.form-control {
+    padding: 0;
+    height: auto;
+    color: inherit;
+    border: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
 }
 
-.simple-box {
-    height: 2.284em;
-    padding-left: 0;
-    outline: none;
-    border: none !important;
-    -webkit-box-shadow: none !important;
-    -moz-box-shadow: none !important;
-    box-shadow: none !important;
+/* Truncates text when not editing */
+.editable .form-control[readonly] {
+    width: 70%;
+    cursor: pointer;
 }
 
-.editable-value {
-    overflow: hidden;
-    display: inline-block;
-    width: 60%;
-    text-overflow: ellipsis;
-    vertical-align: middle;
-}
-
-.editable:hover .editable-value {
-    color: #000;
-}
-
-.inline-edit-wrapper .icons {
-    opacity: .3;
-}
+/* Positions toolbar on the far right and highlights it on hover */
 .icons {
     position: absolute;
     top: 0;
-    right: 2.5px;
-    height: 20px;
+    right: 0;
+    opacity: .3;
 }
-
 .editable:hover .icons {
     opacity: 1;
 }
 
-.pointer {
-    cursor: pointer;
+/* Prevents outline on focus */
+.btn-link {
+    outline: none !important;
 }
+

--- a/src/app/shared/inline-edit.component.html
+++ b/src/app/shared/inline-edit.component.html
@@ -1,22 +1,16 @@
-<div *ngIf="editing">
-    <input type="text"
-           class="form-control form-control-auto simple-box"
-           name="inline-edit-box"
+<div class="inline-edit-wrapper"
+     [ngClass]="{'editable': canEdit, 'text-muted': !editing}">
+    <input class="form-control form-control-auto" type="text"
            [required]="required"
            [(ngModel)]="value"
            [placeholder]="placeholder"
            (blur)="onEditBoxBlur($event)"
            (keyup)="onEditBoxKeyUp($event)"
+           (click)="canEdit && onEditClick()"
+           [readonly]="!editing"
+           name="inline-edit-box"
            #inlineEditBox/>
-</div>
-<div class="inline-edit-wrapper"
-     [ngClass]="{'editable': canEdit}"
-     *ngIf="!editing">
-    <span class="editable-value text-muted"
-          (click)="canEdit && onEditClick()">
-        {{value}}
-    </span>
-    <div class="icons">
+    <div *ngIf="!editing" class="icons">
         <button class="btn btn-xs btn-link"
                 *ngIf="canEdit"
                 (click)="onEditClick()">

--- a/src/app/shared/inline-edit.component.ts
+++ b/src/app/shared/inline-edit.component.ts
@@ -19,31 +19,18 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
         {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => InlineEditComponent), multi: true}
     ]
 })
-export class InlineEditComponent implements AfterViewInit, ControlValueAccessor {
+export class InlineEditComponent implements ControlValueAccessor {
     @Input() required?: boolean = false;
     @Input() disabled?: boolean = false;
     @Input() emptyValue?: string = '';
     @Input() placeholder?: string = '';
     @Output() remove: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChildren('inlineEditBox') private inlineEditBoxQuery: QueryList<ElementRef>;
-
     editing: boolean = false;
-    onChange: any = () => {
-    };
-    onTouched: any = () => {
-    };
+    onChange: any = () => {};
+    onTouched: any = () => {};
 
     private _value: string = '';
-
-    ngAfterViewInit(): void {
-        this.inlineEditBoxQuery.changes.subscribe((list: QueryList <ElementRef>) => {
-            if (list.length > 0) {
-                let inpBox = list.first;
-                inpBox.nativeElement.focus();
-            }
-        });
-    }
 
     get value(): any {
         return this._value;

--- a/src/app/submission-shared/date-input.component.css
+++ b/src/app/submission-shared/date-input.component.css
@@ -17,6 +17,4 @@
 
 .form-control[readonly] {
     cursor: pointer;
-    border: 1px solid #ccc;
-    background: #fff;
 }

--- a/src/app/submission-shared/date-input.component.ts
+++ b/src/app/submission-shared/date-input.component.ts
@@ -45,12 +45,14 @@ export class DateInputComponent implements ControlValueAccessor {
     private onTouched: any = () => {};
 
     /**
-     * Instantiates a new custom component, setting its default format and hiding the weeks column on the calendar.
+     * Instantiates a new custom component, hiding the weeks column on the calendar disabling past dates and setting
+     * its default format.
      * @param {BsDatepickerConfig} config - Configuration object for the datepicker directive
      * @param {ElementRef} rootEl - Reference to the root element of the component's template.
      */
     constructor(config: BsDatepickerConfig, private rootEl: ElementRef) {
         config.showWeekNumbers = false;
+        config.minDate = new Date(Date.now());
         config.dateInputFormat = 'YYYY-MM-DD';
     }
 

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.css
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.css
@@ -4,6 +4,7 @@
     overflow: hidden;
     white-space: nowrap;
 }
+
 .sidebar-contents {
     padding: 15px 0;
     background: #fff;

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.html
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.html
@@ -1,6 +1,19 @@
-<aside class="left-side sidebar sidebar-offcanvas"
-       *ngIf="!readonly">
-    <div class="sidebar-contents clearfix" *ngIf="!collapsed">
+<aside *ngIf="!readonly" class="left-side sidebar sidebar-offcanvas"
+       [ngClass]="{'collapse-left' : collapsed}">
+    <div class="menu-toggle">
+        <button class="minimise-btn btn pull-right"
+                [ngClass]="{'inactive': !collapsed}"
+                [disabled]="editing"
+                (click)="onToggle($event)">
+            <i class="fa fa-fw fa-lg"
+               [ngClass]="{'fa-toggle-left': !collapsed, 'fa-toggle-right': collapsed}"></i>
+        </button>
+        <tabset [ngClass]="{'invisible': collapsed}">
+            <tab heading="Upload form" active="true"></tab>
+        </tabset>
+    </div>
+    <div *ngIf="collapsed" class="vertical-text">Upload form</div>
+    <div class="sidebar-menu sidebar-contents clearfix" *ngIf="!collapsed">
         <form id="subm-upload-form"
               class="col-sm-12"
               name="submUploadForm"

--- a/src/app/submission/direct-submit/direct-submit.component.html
+++ b/src/app/submission/direct-submit/direct-submit.component.html
@@ -3,7 +3,8 @@
             (toggle)="onToggle($event)"
             [collapsed]="collapseSideBar">
     </direct-submit-sidebar>
-    <div class="navbar-default navbar-subm-fixed">
+    <div class="navbar-default navbar-subm-fixed"
+         [ngClass]="{'collapse-left': collapseSideBar}">
         <div class="col-xs-12">
             <a routerLink="/submissions">Submission list</a>
             &nbsp;<i class="fa fa-angle-right font-bold"></i>&nbsp;
@@ -11,10 +12,11 @@
         </div>
     </div>
     <div class="container-fluid">
-        <aside class="right-side navbar-subm-margin">
+        <aside class="right-side navbar-subm-margin"
+               [ngClass]="{'collapse-left': collapseSideBar}">
             <div *ngIf="!request" class="help-msg panel">
                 <div class="panel-body">
-                    <h4>Please fill in the form on the left</h4>
+                    <h4>Please fill out the form on the left</h4>
                     <p>All fields are required. Upon submission, the data file will be validated and any errors shown below.</p>
                 </div>
             </div>

--- a/src/app/submission/direct-submit/direct-submit.component.ts
+++ b/src/app/submission/direct-submit/direct-submit.component.ts
@@ -5,6 +5,7 @@ import {
     DirectSubmitService,
     DirectSubmitRequest
 } from './direct-submit.service';
+import {AppConfig} from "../../app.config";
 
 @Component({
     selector: 'direct-submit',
@@ -14,9 +15,12 @@ export class DirectSubmitComponent implements OnInit, OnDestroy {
     private sb: Subscription;
 
     request: DirectSubmitRequest;
-    collapseSideBar = false;
+    collapseSideBar: Boolean = false;
 
-    constructor(private submitService: DirectSubmitService) {
+    constructor(private submitService: DirectSubmitService, private appConfig: AppConfig) {
+
+        //Initally collapses the sidebar for tablet-sized screens
+        this.collapseSideBar = window.innerWidth < this.appConfig.tabletBreak;
     }
 
     ngOnInit(): void {

--- a/src/app/submission/edit/subm-edit.component.html
+++ b/src/app/submission/edit/subm-edit.component.html
@@ -1,4 +1,5 @@
-<div class="row-offcanvas row-offcanvas-left">
+<div class="row-offcanvas row-offcanvas-left"
+     [ngClass]="{'readonly': readonly}">
     <subm-sidebar *ngIf="!readonly"
                   (toggle)="sideBarCollapsed=!sideBarCollapsed"
                   [collapsed]="sideBarCollapsed"
@@ -7,8 +8,9 @@
                   [errors]="errors">
     </subm-sidebar>
 
-    <subm-navbar
-            [class.collapse-left]="!readonly && sideBarCollapsed"
+    <subm-navbar class="navbar-subm-fixed navbar-default"
+            [ngClass]="{'collapse-left': !readonly && sideBarCollapsed}"
+            [readonly]="readonly"
             [accno]="accno"
             [errors]="errors"
             [sectionPath]="sectionPath"
@@ -17,23 +19,28 @@
     </subm-navbar>
 
     <div class="container-fluid">
-        <aside class="right-side"
-               [ngClass]="{'collapse-left' : !readonly && sideBarCollapsed}">
+        <aside [ngClass]="{'collapse-left' : !readonly && sideBarCollapsed, 'right-side': !readonly}">
             <div *ngIf="subm"
                  (change)="onChange($event)"
                  class="navbar-subm-margin">
 
-                <div class = "panel">
-                    <div class = "panel-body">
-                        <h4>Please fill in the form below</h4>
+                <div *ngIf="isNew" class="panel">
+                    <div class="panel-body">
+                        <h4>Please fill out the form below</h4>
                         <p>
-                            All fields are required unless marked as <i>Optional</i>. The <i>Review</i> tab on the
-                            left-hand side lists any missing or invalid information.
+                            All fields are required unless marked as <i>Optional</i>. The
+                            <span class="font-bold">Review</span> tab on the
+                            left-hand side lists any missing or invalid information, while the
+                            <span class="font-bold">Types</span> tab contains
+                            optional field types that may be added to this submission.
                         </p>
                     </div>
                 </div>
 
-                <subm-form #submForm [section]="section" (keyup.enter)="onSubmit($event)">
+                <subm-form #submForm
+                           [section]="section"
+                           (keyup.enter)="onSubmit($event)"
+                           [readonly]="readonly">
                 </subm-form>
 
                 <div class="list-group">
@@ -61,10 +68,10 @@
                     </div>
                 </div>
 
-                <div class="row row-submit">
+                <div *ngIf="!readonly" class="row row-submit">
                     <p class="col-md-2">
                         <button type="button" class="btn-submit btn btn-primary col-md-12"
-                                [disabled]="isSubmitting || isSaving || readonly"
+                                [disabled]="isSubmitting || isSaving"
                                 (click)="onSubmit($event)">
                             Submit
                         </button>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.css
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.css
@@ -23,17 +23,14 @@
     overflow: hidden;
     width: 100%;
     padding: 0;
+    vertical-align: baseline;
     text-overflow: ellipsis;
     border: none;
 }
 
 /* Other rows */
 .row {
-    margin-top: 15px;
-}
-.row:first-of-type {
-    margin-top: 3px;
-    line-height: 32px;
+    margin-top: 16px;
 }
 .row:last-of-type {
     margin-bottom: 10px;

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="cell canton col-xs-1 col-md-1 text-center">
             <button class="btn-add btn btn-link btn-md" type="button"
-                    *ngIf="!readonly"
+                    [ngClass]="{'invisible': readonly}"
                     [tooltip]="'Add a new ' + feature.typeName.toLowerCase() + ' attribute'"
                     container="body"
                     (click)="feature.addColumn()">
@@ -24,7 +24,8 @@
         <div class="cell heading-cell row-heading col-xs-1 col-md-1 text-center">
             {{rowIdx+1}}
             <button class="btn btn-danger btn-sm" type="button"
-                    *ngIf="!readonly"
+                    [ngClass]="{'invisible': readonly}"
+                    [disabled]="!feature.canRemoveRowAt(index)"
                     (click)="feature.removeRowAt(rowIdx)"
                     [tooltip]="'Delete ' + feature.typeName.toLowerCase() + ' ' + (rowIdx + 1)"
                     container="body">

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -1,10 +1,10 @@
 <div class="container-fluid" [formGroup]="featureForm.form">
     <div class="headings row text-muted">
-        <div class="heading col-xs-3">Key</div>
-        <div class="heading col-xs-9">Value</div>
+        <div class="cell heading col-xs-3">Key</div>
+        <div class="cell heading col-xs-9">Value</div>
     </div>
     <div class="row" #rowEl *ngFor="let column of columns; let idx = index; let first = first; let last = last">
-        <div class="col-xs-3">
+        <div class="cell col-xs-3">
             <div class="form-group key-field">
                 <div class="input-group">
                     <span *ngIf="!readonly && !column.required" class="input-group-btn">
@@ -26,7 +26,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-xs-9">
+        <div class="cell col-xs-9">
             <div class="form-group"
                  [ngClass]="{'has-error': featureForm.rowValueControl(0,column.id).invalid &&
                                           featureForm.rowValueControl(0,column.id).touched}">

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -1,8 +1,7 @@
 <strong class="text-danger" *ngIf="errorNum && feature.size() > 0">Please review the fields below</strong>
-<div class="panel panel-default"
-     *ngIf="feature.size() > 0">
+<div *ngIf="feature.size() > 0" class="panel panel-default feature">
 
-    <div class="panel-heading clearfix">
+    <div *ngIf="!readonly" class="panel-heading clearfix">
         <div class="btn-toolbar pull-left" role="toolbar" *ngIf="!readonly">
             <div class="btn-group" dropdown>
                 <button type="button" class="btn btn-xs btn-default" dropdownToggle>

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -11,7 +11,7 @@
                 <span *ngIf="sectionForm.fieldControl(field.id).invalid && sectionForm.fieldControl(field.id).touched">
                     {{sectionForm.formErrors[field.id] ? sectionForm.formErrors[field.id] : ''}}
                 </span>
-                <small *ngIf="!field.type.required" class="text-muted pull-right"><i>Optional</i></small>
+                <small *ngIf="!readonly && !field.type.required" class="text-muted pull-right"><i>Optional</i></small>
             </label>
             <subm-field
                 [type]="field.valueType"
@@ -28,7 +28,7 @@
     <div *ngFor="let feature of sectionForm.features">
         <span *ngIf="feature.size() > 0">
             <label class="control-label">{{feature.pluralName()}}</label>
-            <small *ngIf="!feature.type.required" class="text-muted pull-right"><i>Optional</i></small>
+            <small *ngIf="!readonly && !feature.type.required" class="text-muted pull-right"><i>Optional</i></small>
         </span>
         <subm-feature [featureForm]="sectionForm.featureForm(feature.id)"
                       [readonly]="readonly">

--- a/src/app/submission/edit/subm-form/subm-form.component.ts
+++ b/src/app/submission/edit/subm-form/subm-form.component.ts
@@ -17,6 +17,7 @@ import {Section} from '../../shared/submission.model';
 })
 export class SubmFormComponent implements OnChanges {
     @Input() section: Section;
+    @Input() readonly: boolean;
 
     sectionForm: SectionForm;
 

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.html
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.html
@@ -1,5 +1,10 @@
-<div class="col-xs-9">
-    <a routerLink="/submissions">Submission list</a>
+<div class="col-xs-8 col-md-9">
+    <a *ngIf="!readonly" routerLink="/submissions">
+        <i class="fa fa-clock-o" aria-hidden="true"></i> Temporary
+    </a>
+    <a *ngIf="readonly" routerLink="/submissions/sent">
+        <i class="fa fa-database" aria-hidden="true"></i> Sent
+    </a>
     <span *ngFor="let sec of sectionPath; let idx = index; let last = last;">
         &nbsp;<i class="fa fa-angle-right font-bold"></i>&nbsp;
         <a href="javascript:void(0)" (click)="onSectionClick(sec)">
@@ -10,14 +15,17 @@
         </a>
     </span>
 </div><!--
---><div class="col-xs-3 btn-toolbar">
-    <button class="button-link btn btn-primary btn-sm btn-submit pull-right"
+--><div class="col-xs-4 col-md-3 btn-toolbar">
+    <button *ngIf="!readonly" class="button-link btn btn-primary btn-sm btn-submit pull-right"
             (click)="onSubmit($event)">
         Submit
     </button>
-    <button class="button-link btn btn-default btn-sm pull-right"
-            *ngIf="errors && !errors.empty()"
+    <button *ngIf="!readonly && errors && !errors.empty()" class="button-link btn btn-default btn-sm pull-right"
             (click)="onErrorsLabelClick($event)">
         View log
+    </button>
+    <button *ngIf="readonly" class="button-link btn btn-primary btn-sm pull-right"
+            (click)="createSubmission()">
+        New submission
     </button>
 </div>

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.ts
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.ts
@@ -4,29 +4,32 @@ import {
     Output,
     EventEmitter
 } from '@angular/core';
+import {Router} from "@angular/router";
 import {BsModalService} from "ngx-bootstrap/modal";
 
-import {
-    Section
-} from '../../shared/submission.model';
+import {Section} from '../../shared/submission.model';
 import {SubmValidationErrorsComponent} from './subm-validation-errors.component';
 import {SubmValidationErrors} from '../../shared/submission.validator';
+import {SubmissionService} from "../../shared/submission.service";
+import {PageTab} from "app/submission/shared/pagetab.model";
 
 @Component({
     selector: 'subm-navbar',
     templateUrl: './subm-navbar.component.html',
-    styleUrls: ['./subm-navbar.component.css'],
-    host: {'class': 'navbar-subm-fixed navbar-default'}
+    styleUrls: ['./subm-navbar.component.css']
 })
 export class SubmNavBarComponent {
     @Input() accno: string;
+    @Input() readonly: boolean;
     @Input() errors: SubmValidationErrors = SubmValidationErrors.EMPTY;
     @Input() sectionPath: Section[];
 
     @Output() sectionClick: EventEmitter<Section> = new EventEmitter<Section>();
     @Output() submitClick: EventEmitter<Section> = new EventEmitter<Section>();
 
-    constructor(private modalService: BsModalService) {}
+    constructor(private modalService: BsModalService,
+                private submService: SubmissionService,
+                private router: Router) {}
 
     onSectionClick(ev: Section): void {
         this.sectionClick.next(ev);
@@ -40,4 +43,15 @@ export class SubmNavBarComponent {
     onSubmit(event): void {
         this.submitClick.next(event);
     }
+
+    /**
+     * Creates a blank submission using PageTab's data structure and brings up a form to edit it.
+     */
+    createSubmission() {
+        this.submService.createSubmission(PageTab.createNew())
+            .subscribe((s) => {
+                console.log('created submission:', s); console.log(PageTab.createNew());
+                this.router.navigate(['/submissions/new', s.accno]);
+            });
+    };
 }

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -3,7 +3,6 @@
     <div class="menu-toggle">
         <button class="minimise-btn btn pull-right"
                 [ngClass]="{'inactive': !collapsed}"
-                [disabled]="editing"
                 (click)="onToggle($event)">
             <i class="fa fa-fw fa-lg"
                [ngClass]="{'fa-toggle-left': !collapsed, 'fa-toggle-right': collapsed}"></i>
@@ -106,7 +105,7 @@
             </li>
             <li class="sidebar-item" *ngFor="let control of formControls; let i = index">
                 <a *ngIf="control.invalid"
-                   tooltip="{{collapsed ? tipText(control.errors) : ''}}"
+                   tooltip="{{collapsed ? '&quot;' + control.template.name + '&quot; field is ' + tipText(control.errors) : ''}}"
                    container="body"
                    placement="right"
                    (click)="onReviewClick(control)">

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.ts
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.ts
@@ -22,10 +22,8 @@ import {
 } from '../../shared/submission.model';
 import { SubmAddDialogComponent } from '../subm-add/subm-add.component';
 import { ConfirmDialogComponent } from 'app/shared/index';
-import { SubmAddEvent } from '../subm-add/subm-add-event.model';
 import { SectionType } from '../../shared/submission-type.model';
 import {SubmValidationErrors} from "../../shared/submission.validator";
-import {SectionForm} from "../subm-form/subm-form.service";
 
 /**
  * Submission item class aggregating its corresponding feature with UI-relevant metadata. It enables
@@ -200,7 +198,6 @@ export class SubmSideBarComponent implements OnChanges {
 
     ngDoCheck() {
         this.numInvalid = this.rootEl.nativeElement.getElementsByClassName('label-danger').length;
-        console.log(this.numInvalid);
     }
 
     onTabClick(isStatus: boolean): void {
@@ -378,13 +375,13 @@ export class SubmSideBarComponent implements OnChanges {
      */
     tipText(errors: ValidationErrors): string {
         if (errors.required) {
-            return 'Blank';
+            return 'blank';
         } else if (errors.maxlength) {
-            return 'Too long';
+            return 'too long';
         } else if (errors.minlength) {
-            return 'Too short';
+            return 'too short';
         } else if (errors.pattern) {
-            return 'Wrong format';
+            return 'wrong format';
         }
     }
 }

--- a/src/app/submission/edit/subm-view.component.ts
+++ b/src/app/submission/edit/subm-view.component.ts
@@ -5,54 +5,30 @@ import {
 
 import {
     ActivatedRoute,
-    Router,
     Params
 } from '@angular/router';
 
-import {
-    Submission,
-    PageTab,
-    DictionaryService
-} from 'app/submission-model/index';
-
-import {SubmissionService} from '../shared/submission.service';
+import {SubmEditComponent} from "./subm-edit.component";
+import {PageTab} from "../shared/pagetab.model";
+import {SubmissionType} from "../shared/submission-type.model";
 
 @Component({
     selector: 'subm-view',
     templateUrl: './subm-edit.component.html',
-    styles: [`
-    .popup {
-      position: absolute;
-      background-color: #fff;
-      border-radius: 3px;
-      border: 1px solid #ddd;
-      height: 251px;
-    }
-`]
 })
-export class SubmViewComponent implements OnInit {
-    submission: Submission;
-    readonly = true;
-
-    constructor(private route: ActivatedRoute,
-                private submService: SubmissionService,
-                private dictService: DictionaryService,
-                private router: Router) {
-    }
-
+export class SubmViewComponent extends SubmEditComponent {
     ngOnInit() {
+        this.readonly = true;
         this.route.params.forEach((params: Params) => {
-            const accno = params['accno'];
+            this.accno = params['accno'];
             this.submService
-                .getSubmittedSubmission(accno)
-                .subscribe(resp => {
-                    const pt = new PageTab(resp.data);
-                    this.submission = pt.asSubmission(this.dictService.dict());
+                .getSubmittedSubmission(this.accno)
+                .subscribe(wrappedSubm => {
+                    this.wrappedSubm = wrappedSubm;
+                    this.accno = wrappedSubm.accno;
+                    this.subm = (new PageTab(wrappedSubm.data)).toSubmission(SubmissionType.createDefault());
+                    this.changeSection(this.subm.root.id);
                 });
         });
-    }
-
-    onEditSubmission() {
-        this.router.navigate(['/submissions', this.submission.accno])
     }
 }

--- a/src/app/submission/list/subm-list.component.html
+++ b/src/app/submission/list/subm-list.component.html
@@ -3,24 +3,32 @@
         <h3>Submissions</h3>
 
         <span class="pull-right">
-            <button class="btn btn-primary btn-sm"
+            <button class="btn btn-primary"
                (click)="uploadSubmission()">
                 <i class="fa fa-upload" aria-hidden="true"></i>
                 <span>Direct upload</span>
             </button>
-            <button class="btn btn-primary btn-sm"
+            <button class="btn btn-primary"
                (click)="createSubmission()">
                 <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                <span>New submission</span>
+                <span>Add new</span>
             </button>
         </span>
         <tabset>
-            <tab heading="Temporary"
-                 [active]="!showSubmitted"
-                 (select)="onSubmTabSelect(false)"></tab>
-            <tab heading="Sent"
-                 [active]="showSubmitted"
-                 (select)="onSubmTabSelect(true)"></tab>
+            <tab [active]="!showSubmitted"
+                 (select)="onSubmTabSelect(false)">
+                <template tabHeading>
+                    <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    Temporary
+                </template>
+            </tab>
+            <tab [active]="showSubmitted"
+                 (select)="onSubmTabSelect(true)">
+                <template tabHeading>
+                    <i class="fa fa-database" aria-hidden="true"></i>
+                    Sent
+                </template>
+            </tab>
         </tabset>
         <section>
             <div class="panel panel-info">
@@ -36,6 +44,9 @@
                 </div>
             </div>
         </section>
+        <a href="https://www.ebi.ac.uk/biostudies/studies/" target="_blank">
+            <i class="fa fa-fw fa-external-link-square"></i>Search published submissions
+        </a>
     </aside>
 </container-root>
 

--- a/src/app/submission/results/subm-results-modal.component.html
+++ b/src/app/submission/results/subm-results-modal.component.html
@@ -35,9 +35,10 @@
 <div class="modal-footer">
     <div class="pull-right">
         <button type="button" class="btn btn-xs"
+                tooltip="{{isSuccess() ? 'List all submissions sent' : 'Go back to the current submission'}}"
                 [ngClass]="{'btn-primary': isSuccess(), 'btn-default': !isSuccess()}"
                 (click)="onConfirm()">
-            {{isSuccess() ? 'Go to submissions' : 'Review submission'}}
+            {{isSuccess() ? 'Show all sent' : 'Review submission'}}
         </button>
     </div>
 </div>

--- a/src/app/submission/results/subm-results-modal.component.ts
+++ b/src/app/submission/results/subm-results-modal.component.ts
@@ -55,10 +55,10 @@ export class SubmResultsModalComponent {
     }
 
     /**
-     * Handler for confirmation event. Hides the modal, possibly redirecting to list of submissions.
+     * Handler for confirmation event. Hides the modal, possibly redirecting to list of sent submissions.
      */
     onConfirm(): void {
         this.bsModalRef.hide();
-        this.isSuccess() && this.router.navigate(['/submissions']);
+        this.isSuccess() && this.router.navigate(['/submissions/sent']);
     }
 }

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -10,8 +10,7 @@ export const DefaultTemplate = {
             'columnTypes': [
                 {
                     'name': 'Organism',
-                    'valueType': 'text',
-                    'required': true
+                    'valueType': 'text'
                 },
                 {
                     'name': 'Experimental design',

--- a/src/config.json
+++ b/src/config.json
@@ -1,1 +1,8 @@
-{"APP_PROXY_BASE":"/proxy","APP_CONTEXT":"/","APP_DEBUG_ENABLED":true,"APP_PROD":true,"APP_VERSION":"2.3.4"}
+{
+  "APP_PROXY_BASE":"/proxy",
+  "APP_CONTEXT":"/",
+  "APP_DEBUG_ENABLED":true,
+  "APP_PROD":true,
+  "APP_VERSION":"2.5",
+  "APP_TABLET_BREAKPOINT": 993
+}

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BioStudies Submission Tool</title>
+    <title>Submission Tool</title>
     <style>
         /* Styles for optimised rendering path */
         *{box-sizing:border-box}body,html{height:100%;margin:0;padding:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;font-size:14px;line-height:1.42857143;background:#fafafa}.loading-logo{position:absolute;top:50%;left:50%;width:80%;max-width:600px;transform:translateX(-50%) translateY(-50%)}@-webkit-keyframes fadeIn{from{opacity:1}to{opacity:0}}@-moz-keyframes fadeIn{from{opacity:1}to{opacity:0}}@keyframes fadeIn{from{opacity:1}to{opacity:0}}.fade-effect .pages{-webkit-animation:fadeIn ease-in infinite;-moz-animation:fadeIn ease-in infinite;animation:fadeIn ease-in infinite;-webkit-animation-direction:alternate-reverse;-moz-animation-direction:alternate-reverse;animation-direction:alternate-reverse;-webkit-animation-duration:2s;-moz-animation-duration:2s;animation-duration:2s}.fade-effect .bottom-pages{-webkit-animation-delay:.5s;-moz-animation-delay:.5s;animation-delay:.5s}.fade-effect .middle-pages{-webkit-animation-delay:1s;-moz-animation-delay:1s;animation-delay:1s}.fade-effect .upper-pages{-webkit-animation-delay:1.5s;-moz-animation-delay:1.5s;animation-delay:1.5s}.fade-effect .top-pages{-webkit-animation-delay:2s;-moz-animation-delay:2s;animation-delay:2s}.loading-message{margin:10px 0;text-align:center;font-size:20px;color:#58595B}

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -12,14 +12,21 @@
 .navbar-subm-fixed {
   position: fixed !important;
   top: @navbar-height;
+  width: 100%;
+  min-height: 54px;
+  display: flex;
+  align-items: center;
   z-index: @zindex-navbar;
   padding: 13px 0 12px @left-side-width;
-  width: 100%;
 
   & > div {
     float: none;
     display: inline-block;
     vertical-align: middle;
+  }
+
+  .readonly & {
+    padding: 0;
   }
 }
 
@@ -60,29 +67,18 @@ aside {
   transition: width .3s ease;
 }
 
-/*@media screen and (min-width: @screen-md) { */
+.right-side.collapse-left {
+  margin-left: @left-side-width-collapse;
+  display: block !important;
+}
 
-  .right-side.collapse-left {
-    margin-left: @left-side-width-collapse;
-    display: block !important;
-  }
+.navbar-subm-fixed.collapse-left {
+  padding-left: @left-side-width-collapse;
+}
 
-  .navbar-subm-fixed.collapse-left {
-    padding-left: @left-side-width-collapse;
-  }
-
-  /*.right-side.ng-hide {
-    display: block !important;
-    margin-left: 0;
-    > .content-header {
-      margin-top: 0;
-    }
-  }
-*/
-  .left-side.collapse-left {
-    width: @left-side-width-collapse;
-  }
-/*}*/
+.left-side.collapse-left {
+  width: @left-side-width-collapse;
+}
 
 @media screen and (max-width: @screen-md) {
   .right-side {
@@ -123,6 +119,17 @@ aside {
     .nav-tabs > li > a {
       padding: 10px 12px;
     }
+  }
+
+  .vertical-text {
+    position: absolute;
+    top: 50%;
+    left: -50px;
+    text-transform: uppercase;
+    color: #fff;
+    font-weight: bold;
+    letter-spacing: 3px;
+    white-space: nowrap;
   }
 
   &.collapse-left .menu-toggle {
@@ -191,52 +198,10 @@ aside {
   }
 }
 
-/*
- * Off Canvas
- * --------------------------------------------------
- */
-/*@media screen and (max-width: @screen-md) {
-  .row-offcanvas {
-    position: relative;
-    -webkit-transition: all .25s ease-out;
-    -o-transition: all .25s ease-out;
-    transition: all .25s ease-out;
-  }
-
-  .row-offcanvas-right {
-    right: 0;
-  }
-
-  .row-offcanvas-left {
-    left: 0;
-  }
-
-  .row-offcanvas-right
-  .sidebar-offcanvas {
-    right: -@left-side-width;
-  }
-
-  .row-offcanvas-left
-  .sidebar-offcanvas {
-    left: -@left-side-width;
-  }
-
-  .row-offcanvas-right.active {
-    right: @left-side-width;
-  }
-
-  .row-offcanvas-left.active {
-    left: @left-side-width;
-  }
-
-  .sidebar-offcanvas {
-    position: absolute;
-    top: 0;
-    width: @left-side-width;
-  }
-}*/
-
-/* Makes unselected tabs be on a plane behind selected ones with a permanent shaded appearance */
+/* Makes unselected tabs be on a plane behind selected ones with a permanent shaded appearance. Also bumps up their weight */
+.nav-tabs > .nav-item > .nav-link {
+  font-weight: 500;
+}
 .nav-tabs > .nav-item > .nav-link:not(.active) {
   background: @gray-lighter;
 }
@@ -244,15 +209,24 @@ aside {
   z-index: 100;
 }
 
-/* Gives readonly inputs the appearance of standard text */
-input[readonly] {
+/* Gives readonly inputs and features the appearance of standard text */
+input[readonly], textarea[readonly] {
   font-size: @font-size-base;
+  text-overflow: ellipsis;
   background: #fff !important;
-  box-shadow: none;
-  border: none;
+}
+.readonly .form-control, .readonly .feature {
+  border: none !important;
+  box-shadow: none !important;
+}
+.readonly .feature .form-control {
+  padding-left: 0;
+}
+.readonly .dropdown:after {
+  display: none;
 }
 
-/* Utility classes for top-right-corner badge indicators */
+/* Convenience classes for top-right-corner badge indicators */
 .badge-parent {
   position: relative;
 }
@@ -265,7 +239,36 @@ input[readonly] {
   background: @brand-danger !important;
 }
 
-//Utility class for bold typography
+//Convenience class for bold typography
 .font-bold {
   font-weight: bold;
+}
+
+//Convenience text for vertical clockwise text
+.vertical-text {
+  transform: rotate(-90deg);
+}
+
+//Brings date picker's styles in line with the app.
+.bs-datepicker {
+  z-index: 2000;
+  border-radius: 4px;
+}
+.bs-datepicker .bs-datepicker-head {
+  background: @brand-primary;
+}
+.bs-datepicker .selected {
+  background: @brand-primary !important;
+}
+.bs-datepicker-container {
+  padding: 0;
+}
+.bs-datepicker-body table td {
+  color: @link-color;
+}
+.bs-datepicker-body table td span:not(.disabled):not(.is-other-month) {
+  font-weight: 500;
+}
+.bs-datepicker-body table td span.disabled, .bs-datepicker-body table td.disabled span {
+  cursor: default;
 }

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -156,6 +156,11 @@
 .ag-cell {
   outline: none !important;
 }
+.ag-fresh .ag-cell-focus {
+  border-left: none;
+  border-top: none;
+  border-bottom: none;
+}
 
 //Prevents page controls from wrapping onto the next line when on pad-sized screens
 .ag-fresh .ag-paging-row-summary-panel {
@@ -180,6 +185,7 @@ component */
   cursor: pointer;
 }
 
+//Makes validation popovers show up only when there is indeed an error.
 .validation-pop {
   visibility: hidden;
   min-width: 300px;
@@ -187,19 +193,4 @@ component */
 }
 .has-error .validation-pop {
   visibility: visible;
-}
-
-//Brings date picker's styles in line with the app.
-.bs-datepicker {
-  z-index: 2000;
-  border-radius: 4px;
-}
-.bs-datepicker .bs-datepicker-head {
-  background: #3c8b9f;
-}
-.bs-datepicker .selected {
-  background: #3c8b9f !important;
-}
-.theme-green .bs-datepicker-container {
-  padding: 0;
 }


### PR DESCRIPTION
- Adds micro-states to submission list with component reuse for the "temporary" and "sent" subviews.
- Removes view/undo buttons for temporary submissions and disallows editing of sent ones.
- Refactors the SubmEdit and SubmView component classes to allow for restricted viewing of sent submissions.
- Exposes the breakpoint for tablet-sized devices as a global configuration option.
- Simplifies InlineEdit component by using an input control at all times, thus avoiding artefacts while switching between the display and edit views.
- Disables past dates in the date picker.