### PR TITLE
 Scroll pending fields into view and other fixes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -63,6 +63,7 @@ const appRoutes: Routes = [
     {
         path: 'submissions/:accno',
         component: SubmViewComponent,
+        data: {reuse: true},
         canActivate: [AuthGuard]
     },
     {
@@ -70,6 +71,9 @@ const appRoutes: Routes = [
         component: FileListComponent,
         canActivate: [AuthGuard]
     }
+
+    //NOTE: some components should be reused instead of re-instantiated when navigating to certain routes (the ones with a "reuse" data property).
+    //TODO: As of now, angular does not support this feature but is soon to be added (https://github.com/angular/angular/issues/12446). We should take advantage of this to save requests.
 ];
 
 @NgModule({

--- a/src/app/auth/model/app-path.ts
+++ b/src/app/auth/model/app-path.ts
@@ -11,7 +11,6 @@ export class AppPath {
 
     private getAppPath(ancor: string = '') {
         let loc = window.location;
-        console.log(loc, loc.pathname);
         return loc.origin + loc.pathname + ancor;
     }
 }

--- a/src/app/file/file-list.component.ts
+++ b/src/app/file/file-list.component.ts
@@ -168,13 +168,14 @@ export class FileListComponent implements OnInit, OnDestroy {
             onGridReady: () => {
                 this.gridOptions.api.sizeColumnsToFit();
             },
-            rowSelection: 'single'
+            rowSelection: 'single',
+            unSortIcon: true,
+            localeText: {noRowsToShow: 'No files found'}
         };
 
         this.uploadSubscription = this.fileUploadService.uploadFinish$
             .filter((path) => path.startsWith(this.currentPath))
             .subscribe(() => {
-                console.log('on upload finished');
                 this.loadData();
             });
         this.rowData = [];
@@ -183,13 +184,12 @@ export class FileListComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.route.params.forEach((params: Params) => {
-            this.backButton = params['bb'];
+        this.route.queryParams.forEach((params: Params) => {
+            this.backButton = params.bb;
         });
     }
 
     ngOnDestroy() {
-        console.log('onDestroy()');
         this.uploadSubscription.unsubscribe();
     }
 
@@ -210,7 +210,8 @@ export class FileListComponent implements OnInit, OnDestroy {
             {
                 headerName: 'Type',
                 field: 'type',
-                width: 30,
+                minWidth: 45,
+                maxWidth: 45,
                 suppressSorting: true,
                 cellRendererFramework: FileTypeCellComponent
             },
@@ -220,12 +221,12 @@ export class FileListComponent implements OnInit, OnDestroy {
             },
             {
                 headerName: 'Progress',
-                width: 200,
+                maxWidth: 200,
                 cellRendererFramework: ProgressCellComponent
             },
             {
                 headerName: 'Actions',
-                width: 100,
+                maxWidth: 100,
                 suppressMenu: true,
                 suppressSorting: true,
                 cellRendererFramework: FileActionsCellComponent
@@ -313,7 +314,6 @@ export class FileListComponent implements OnInit, OnDestroy {
     }
 
     private removeFile(fileName: string): void {
-        console.log('removeFile', fileName);
         this.fileService
             .removeFile(this.path.fullPath(fileName))
             .subscribe((resp) => {

--- a/src/app/file/file-upload.service.ts
+++ b/src/app/file/file-upload.service.ts
@@ -46,7 +46,6 @@ export class FileUpload {
 
         let uploadStatus = upload
             .map((res) => {
-                console.log(res);
                 if (res.kind === 'progress') {
                     return new FileUploadStatus('uploading', res.progress, undefined);
                 }
@@ -59,9 +58,7 @@ export class FileUpload {
                 return failed;
             });
 
-        this._statusSubject.subscribe(
-            (fus) => {
-                console.log(fus);
+        this._statusSubject.subscribe((fus) => {
                 this._progress = fus.progress;
                 this._status = fus.status;
                 this._error = fus.error;
@@ -70,8 +67,7 @@ export class FileUpload {
                     this.finish$.complete();
                     this._statusSubject.complete();
                 }
-            },
-            console.log);
+            }, console.log);
 
         this._sb = uploadStatus.subscribe(this._statusSubject);
     }
@@ -144,7 +140,6 @@ export class FileUploadService {
     }
 
     remove(u: FileUpload) {
-        console.log("remove upload", u, this._uploads);
         _.pull(this._uploads, u);
     }
 }

--- a/src/app/file/user-dirs-sidebar.component.ts
+++ b/src/app/file/user-dirs-sidebar.component.ts
@@ -24,7 +24,10 @@ import {FileService} from './file.service';
         <button class="minimise-btn btn pull-right"
                 [ngClass]="{'inactive': !collapsed}"
                 [disabled]="editing"
-                (click)="onToggle($event)">
+                (click)="onToggle($event)"
+                tooltip="{{collapsed ? 'Maximize sidebar' : 'Minimize sidebar'}}"
+                container="body"
+                placement="right">
             <i class="fa fa-fw fa-lg"
                [ngClass]="{'fa-toggle-left': !collapsed, 'fa-toggle-right': collapsed}"></i>
         </button>
@@ -115,7 +118,6 @@ export class UserDirsSideBarComponent implements OnInit, ControlValueAccessor {
     }
 
     onDirSelect(d) {
-        console.log(d);
         this.value = d.path;
         if (this.select) {
             this.select.emit(d.path);

--- a/src/app/shared/inline-edit.component.html
+++ b/src/app/shared/inline-edit.component.html
@@ -1,6 +1,6 @@
 <div class="inline-edit-wrapper"
      [ngClass]="{'editable': canEdit, 'text-muted': !editing}">
-    <input class="form-control form-control-auto" type="text"
+    <input class="form-control form-control-auto" type="text" tabindex="-1"
            [required]="required"
            [(ngModel)]="value"
            [placeholder]="placeholder"

--- a/src/app/shared/multi-select.component.ts
+++ b/src/app/shared/multi-select.component.ts
@@ -127,7 +127,6 @@ export class MultiSelectComponent implements ControlValueAccessor, OnChanges, On
 
     ngOnChanges(): void {
         this.items = this.options.map(opt => ({checked: false, label: opt}));
-        console.log(this.items);
         this.selected = [];
         this.onChange(this.selected);
     }

--- a/src/app/submission-shared/date-input.component.css
+++ b/src/app/submission-shared/date-input.component.css
@@ -1,9 +1,13 @@
+/* Prevents the input from taking up all horizontal space */
+/* NOTE: it is assumed that the control will be subject to Bootstrap styling */
 .dropdown {
     position: relative;
     width: 15rem;
+    height: 34px;
     cursor: pointer;
 }
 
+/* Ensures the control is understood as a select-like interactive element */
 .dropdown:after {
     position: absolute;
     content: "\25BC";
@@ -13,8 +17,16 @@
     width: 20px;
     transform: translateY(-50%);
     text-align: center;
+    z-index: 100;
+}
+.form-control {
+    cursor: pointer;
 }
 
-.form-control[readonly] {
-    cursor: pointer;
+/* Do not display interactivity cues if datepicker is meant to be read-only */
+.readonly.dropdown:after {
+    display: none;
+}
+.readonly .form-control {
+    cursor: default;
 }

--- a/src/app/submission-shared/date-input.component.html
+++ b/src/app/submission-shared/date-input.component.html
@@ -1,4 +1,6 @@
-<div class="dropdown" (click)="onClick($event)">
+<div class="dropdown"
+     [ngClass]="{'readonly': readonly}"
+     (click)="onClick($event)">
     <input type="text" class="form-control" readonly
            bsDatepicker
            (bsValueChange)="onPickerSet($event)"

--- a/src/app/submission-shared/date-input.component.ts
+++ b/src/app/submission-shared/date-input.component.ts
@@ -39,6 +39,7 @@ export class DateInputComponent implements ControlValueAccessor {
     private dateValue: Date;
 
     @Input() required?: boolean = false;
+    @Input() readonly?: boolean = false;
     @ViewChild('dp') private datepicker: BsDatepickerComponent;
 
     private onChange: any = () => {};
@@ -92,11 +93,17 @@ export class DateInputComponent implements ControlValueAccessor {
 
     /**
      * Normalises clicking behaviour across all of the input. Otherwise, clicking around the area of the arrow would
-     * not bring up the calenda, the expected behaviour.
+     * not bring up the calendar, the expected behaviour.
      * @param {Event} event - DOM event for the click action.
      */
     onClick(event: Event) {
-        if ((<Element>event.target).classList.contains('dropdown')) {  //checks click happened on the wrapping element
+
+        //Cancels the datepicker dialogue by closing it as soon as it's opened.
+        if (this.readonly) {
+            this.datepicker.toggle();
+
+        //Checks click happened on the wrapping element
+        } else if ((<Element>event.target).classList.contains('dropdown')) {
             this.datepicker.show();
         }
     }

--- a/src/app/submission-shared/file-input.component.css
+++ b/src/app/submission-shared/file-input.component.css
@@ -1,6 +1,6 @@
-.input-sm {
+.no-files {
     color: #317181;
 }
-.input-sm:hover {
+.no-files:hover {
     color: #1c404a;
 }

--- a/src/app/submission-shared/file-input.component.html
+++ b/src/app/submission-shared/file-input.component.html
@@ -6,8 +6,9 @@
          [disabled]="readonly">
     <option *ngFor="let file of files" [value]="file">{{file}}</option>
 </select>
-<a *ngIf="files.length == 0" class="form-control input-sm"
-   [routerLink]="['/files',{bb:'1'}]">
+<a *ngIf="files.length == 0" class="form-control input-sm no-files"
+   routerLink="/files"
+   [queryParams]="{bb: true}">
     Upload a file
     <i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
 </a>

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.html
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.html
@@ -4,7 +4,10 @@
         <button class="minimise-btn btn pull-right"
                 [ngClass]="{'inactive': !collapsed}"
                 [disabled]="editing"
-                (click)="onToggle($event)">
+                (click)="onToggle($event)"
+                tooltip="{{collapsed ? 'Maximize sidebar' : 'Minimize sidebar'}}"
+                container="body"
+                placement="right">
             <i class="fa fa-fw fa-lg"
                [ngClass]="{'fa-toggle-left': !collapsed, 'fa-toggle-right': collapsed}"></i>
         </button>

--- a/src/app/submission/edit/subm-edit.component.html
+++ b/src/app/submission/edit/subm-edit.component.html
@@ -24,15 +24,36 @@
                  (change)="onChange($event)"
                  class="navbar-subm-margin">
 
-                <div *ngIf="isNew" class="panel">
+                <div *ngIf="isNew && errors.total()" class="panel">
                     <div class="panel-body">
-                        <h4>Please fill out the form below</h4>
+                        <h4>New submission</h4>
                         <p>
-                            All fields are required unless marked as <i>Optional</i>. The
+                            Please fill out the form below. All fields are required unless marked as <i>Optional</i>. The
                             <span class="font-bold">Review</span> tab on the
                             left-hand side lists any missing or invalid information, while the
                             <span class="font-bold">Types</span> tab contains
                             optional field types that may be added to this submission.
+                        </p>
+                    </div>
+                </div>
+
+                <div *ngIf="!isNew && errors.total()" class="panel">
+                    <div class="panel-body">
+                        <h4>Incomplete submission</h4>
+                        <p>
+                            Some information in this submission is still missing or incorrect. Please
+                            note that all fields are required unless marked as <i>Optional</i>. Check the
+                            <span class="font-bold">Review</span> tab on the left-hand side for more help.
+                        </p>
+                    </div>
+                </div>
+
+                <div *ngIf="!errors.total() && !readonly" class="panel">
+                    <div class="panel-body">
+                        <h4>Study ready for submission</h4>
+                        <p>
+                            You may submit the data on this form now. After submission, your study will be allocated
+                            a permanent accession number under which it will be published.
                         </p>
                     </div>
                 </div>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -1,7 +1,7 @@
 <div class="container-fluid container-scroll" [formGroup]="featureForm.form">
     <div class="row">
         <div class="cell canton col-xs-1 col-md-1 text-center">
-            <button class="btn-add btn btn-link btn-md" type="button"
+            <button class="btn-add btn btn-link btn-md" type="button" tabindex="-1"
                     [ngClass]="{'invisible': readonly}"
                     [tooltip]="'Add a new ' + feature.typeName.toLowerCase() + ' attribute'"
                     container="body"
@@ -51,9 +51,7 @@
         </div>
     </div>
 </div>
-<button *ngIf="!readonly"
-        type="button"
-        class="btn-add btn btn-link"
+<button *ngIf="!readonly" type="button" class="btn-add btn btn-link" tabindex="-1"
         [tooltip]="'Add a new ' + feature.typeName.toLowerCase()"
         container="body"
         (click)="feature.addRow()">

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -58,5 +58,5 @@
         container="body"
         (click)="feature.addRow()">
     <i class="fa fa-lg {{feature.type.icon}}"></i>
-    &nbsp;Add row
+    &nbsp;Add {{feature.typeName.toLowerCase()}} row
 </button>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -8,7 +8,7 @@
             <div class="form-group key-field">
                 <div class="input-group">
                     <span *ngIf="!readonly && !column.required" class="input-group-btn">
-                          <button type="button"
+                          <button type="button" tabindex="-1"
                                   class="btn btn-sm btn-danger btn-flat"
                                   (click)="featureForm.feature.removeRowAt(idx)"
                                   [disabled]="!feature.canRemoveRowAt(idx)"

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -11,6 +11,7 @@
                           <button type="button"
                                   class="btn btn-sm btn-danger btn-flat"
                                   (click)="featureForm.feature.removeRowAt(idx)"
+                                  [disabled]="!feature.canRemoveRowAt(idx)"
                                   [tooltip]="'Delete ' + feature.typeName.toLowerCase() + ' entry'">
                                <i class="fa fa-trash-o"></i>
                           </button>
@@ -53,7 +54,7 @@
                 [tooltip]="'Add a new ' + feature.typeName.toLowerCase()"
                 (click)="feature.addColumn()">
             <i class="fa fa-lg {{feature.type.icon}}"></i>
-            &nbsp;Add row
+            &nbsp;Add {{feature.typeName.toLowerCase()}} row
         </button>
     </div>
 </div>

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.css
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.css
@@ -1,0 +1,8 @@
+.panel-heading .fa {
+    color: #777777;
+}
+.panel-description {
+    display: inline-block;
+    margin: 0 .5rem;
+    width: 83%;
+}

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -2,7 +2,7 @@
 <div *ngIf="feature.size() > 0" class="panel panel-default feature">
 
     <div *ngIf="!readonly" class="panel-heading clearfix">
-        <div class="btn-toolbar pull-left" role="toolbar" *ngIf="!readonly">
+        <div *ngIf="isMenu" class="btn-toolbar pull-left" role="toolbar">
             <div class="btn-group" dropdown>
                 <button type="button" class="btn btn-xs btn-default" dropdownToggle>
                     <i class="fa fa-bars" aria-hidden="true"></i>
@@ -14,7 +14,8 @@
                 </ul>
             </div>
         </div>
-        <span class="panel-description col-xs-10">{{feature.type.description}}</span>
+        <i class="fa fa-lg {{feature.type.icon}}"></i>
+        <span class="panel-description">{{feature.type.description}}</span>
         <span class="label label-danger pull-right" *ngIf="errorNum">{{errorNum}} error{{errorNum > 1 ? 's' : ''}}</span>
     </div>
 

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -10,11 +10,13 @@ import {FeatureForm} from '../subm-form.service';
 
 @Component({
     selector: 'subm-feature',
-    templateUrl: './subm-feature.component.html'
+    templateUrl: './subm-feature.component.html',
+    styleUrls: ['./subm-feature.component.css']
 })
 export class SubmFeatureComponent implements OnInit {
     @Input() featureForm: FeatureForm;
     @Input() readonly?: boolean = false;
+    @Input() isMenu?: boolean = true;
     @ViewChild('featureEl') featureEl: ElementRef;
 
     actions: any[] = [];

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -17,6 +17,7 @@
         *ngIf="type === 'date'"
         [(ngModel)]="value"
         [required]="required"
+        [readonly]="readonly"
         (focusout)="onBlur()">
 </date-input>
 

--- a/src/app/submission/edit/subm-form/subm-form.component.css
+++ b/src/app/submission/edit/subm-form/subm-form.component.css
@@ -1,0 +1,4 @@
+.input-group-addon {
+    color: #777777;
+    background: #eeeeee !important;
+}

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -13,15 +13,20 @@
                 </span>
                 <small *ngIf="!readonly && !field.type.required" class="text-muted pull-right"><i>Optional</i></small>
             </label>
-            <subm-field
-                [type]="field.valueType"
-                [name]="field.name"
-                [readonly]="readonly"
-                [required]="field.type.required"
-                [(ngModel)]="field.value"
-                [formControl]="sectionForm.fieldControl(field.id)"
-                validate-onblur>
-            </subm-field>
+            <div class="input-group">
+                <span class="input-group-addon">
+                    <i class="fa {{sectionForm.fieldControl(field.id).parentType.icon}}"></i>
+                </span>
+                <subm-field class="subm-field"
+                    [type]="field.valueType"
+                    [name]="field.name"
+                    [readonly]="readonly"
+                    [required]="field.type.required"
+                    [(ngModel)]="field.value"
+                    [formControl]="sectionForm.fieldControl(field.id)"
+                    validate-onblur>
+                </subm-field>
+            </div>
         </div>
     </div>
 
@@ -30,7 +35,8 @@
             <label class="control-label">{{feature.pluralName()}}</label>
             <small *ngIf="!readonly && !feature.type.required" class="text-muted pull-right"><i>Optional</i></small>
         </span>
-        <subm-feature [featureForm]="sectionForm.featureForm(feature.id)"
+        <subm-feature [isMenu]="false"
+                      [featureForm]="sectionForm.featureForm(feature.id)"
                       [readonly]="readonly">
         </subm-feature>
     </div>

--- a/src/app/submission/edit/subm-form/subm-form.component.ts
+++ b/src/app/submission/edit/subm-form/subm-form.component.ts
@@ -13,7 +13,8 @@ import {Section} from '../../shared/submission.model';
 
 @Component({
     selector: 'subm-form',
-    templateUrl: './subm-form.component.html'
+    templateUrl: './subm-form.component.html',
+    styleUrls: ['./subm-form.component.css']
 })
 export class SubmFormComponent implements OnChanges {
     @Input() section: Section;

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.html
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.html
@@ -10,7 +10,7 @@
         <a href="javascript:void(0)" (click)="onSectionClick(sec)">
             <span [ngClass]="{'current-section': last}">
                 <span *ngIf="idx == 0">{{accno}}</span>
-                <span *ngIf="idx > 0">{{sec.typeName + ' subsection'}}</span>
+                <span *ngIf="idx > 0">{{sec.typeName}}</span>
             </span>
         </a>
     </span>

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.ts
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.ts
@@ -46,12 +46,12 @@ export class SubmNavBarComponent {
 
     /**
      * Creates a blank submission using PageTab's data structure and brings up a form to edit it.
+     * //TODO: at present, the app relies on the backend to generate a ready instance of a submission. This leads to two requests for every new submission, one to create it and another to retrieve it for the edit view.
      */
     createSubmission() {
         this.submService.createSubmission(PageTab.createNew())
             .subscribe((s) => {
-                console.log('created submission:', s); console.log(PageTab.createNew());
-                this.router.navigate(['/submissions/new', s.accno]);
+                this.router.navigate(['/submissions/new/', s.accno]);
             });
     };
 }

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -3,7 +3,10 @@
     <div class="menu-toggle">
         <button class="minimise-btn btn pull-right"
                 [ngClass]="{'inactive': !collapsed}"
-                (click)="onToggle($event)">
+                (click)="onToggle($event)"
+                tooltip="{{collapsed ? 'Maximize sidebar' : 'Minimize sidebar'}}"
+                container="body"
+                placement="right">
             <i class="fa fa-fw fa-lg"
                [ngClass]="{'fa-toggle-left': !collapsed, 'fa-toggle-right': collapsed}"></i>
         </button>
@@ -13,7 +16,8 @@
                  (select)="onTabClick(true)">
                 <template tabHeading>
                     Review
-                    <span *ngIf="numInvalid" class="badge badge-corner badge-danger">{{numInvalid}}</span>
+                    <span *ngIf="errors.total()" class="badge badge-corner"
+                          [ngClass]="{'badge-danger': numPending}">{{errors.total()}}</span>
                 </template>
             </tab>
             <tab heading="Types"
@@ -102,13 +106,14 @@
                 <i class="fa fa-check-circle" aria-hidden="true"
                     [ngClass]="{'fa-2x': collapsed, 'fa-4x': !collapsed}"></i>
                 <h4>All fields are valid</h4>
+                <h4>You may submit your study now</h4>
             </li>
             <li class="sidebar-item" *ngFor="let control of formControls; let i = index">
                 <a *ngIf="control.invalid"
                    tooltip="{{collapsed ? '&quot;' + control.template.name + '&quot; field is ' + tipText(control.errors) : ''}}"
                    container="body"
                    placement="right"
-                   (click)="onReviewClick(control)">
+                   (click)="onReviewClick($event, control)">
                     <i class="fa fa-lg text-center {{control.parentType.icon}}"></i>
                     {{!collapsed ? '&nbsp;' + control.template.name + '&nbsp;' : ''}}
                     <strong class="label label-default"

--- a/src/app/submission/edit/subm-view.component.ts
+++ b/src/app/submission/edit/subm-view.component.ts
@@ -24,9 +24,11 @@ export class SubmViewComponent extends SubmEditComponent {
             this.submService
                 .getSubmittedSubmission(this.accno)
                 .subscribe(wrappedSubm => {
+                    const page = new PageTab(wrappedSubm.data);
+
                     this.wrappedSubm = wrappedSubm;
                     this.accno = wrappedSubm.accno;
-                    this.subm = (new PageTab(wrappedSubm.data)).toSubmission(SubmissionType.createDefault());
+                    this.subm = page.toSubmission(SubmissionType.createDefault());
                     this.changeSection(this.subm.root.id);
                 });
         });

--- a/src/app/submission/list/subm-list.component.css
+++ b/src/app/submission/list/subm-list.component.css
@@ -6,3 +6,10 @@
 .panel-heading {
     border-top-left-radius: 0;
 }
+
+/* Hides button text for small screens */
+@media screen and (max-width: 650px) {
+    .btn-primary span {
+        display: none;
+    }
+}

--- a/src/app/submission/results/subm-results-modal.component.html
+++ b/src/app/submission/results/subm-results-modal.component.html
@@ -16,9 +16,9 @@
         <div class="media-body media-middle">
             <p class="media-heading">
                 <span *ngIf="isSuccess()">
-                    Your submission has been added successfully to BioStudies with accession number <strong>{{getAccno()}}</strong>. It
-                    will be available in the next 24 hours at <a target="_blank" href="http://www.ebi.ac.uk/biostudies/studies/{{getAccno()}}">
-                    www.ebi.ac.uk/biostudies/studies/{{getAccno()}}</a>.
+                    Your submission has been successfully added to the BioStudies database with accession number <strong>{{accno}}</strong>. It
+                    will be available in the next 24 hours at <a target="_blank" href="{{location.origin}}/biostudies/studies/{{accno}}">
+                    {{location.hostname}}/biostudies/studies/{{accno}}</a>.
                 </span>
                 <span *ngIf="!isSuccess()">
                     An error has occurred while submitting the data to BioStudies. You may review your submission and try again. If the error

--- a/src/app/submission/results/subm-results-modal.component.ts
+++ b/src/app/submission/results/subm-results-modal.component.ts
@@ -25,12 +25,16 @@ export class SubmResultsModalComponent {
                 public bsModalRef: BsModalRef) {
     }
 
+    get location() {
+        return window.location;
+    }
+
     /**
      * Extracts the accession number from the server's response, taking into account whether the
      * study is new or not. The former will have its accession number added under the mapping section.
      * @returns {string} Accession number assigned to the submitted study
      */
-    getAccno(): string {
+    get accno(): string {
         if (this.mapping.length && this.mapping[0].hasOwnProperty('assigned') && this.mapping[0].assigned) {
             return this.mapping[0].assigned;
         } else {

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -645,8 +645,14 @@ export class Section extends HasUpdates<UpdateEvent> {
         this._accno = data.accno || '';
 
         this.fields = new Fields(type, data);
+
+        //Any attribute names that do not match field names are added as annotations.
+        //NOTE: Attribute names are camel-cased whereas field names are in human-readable form with spaces.
         this.annotations = AnnotationFeature.create(type.annotationsType,
-            (data.attributes || []).filter(a => type.getFieldType(a.name) === undefined)
+            (data.attributes || []).filter((attribute) => {
+                const humanName = attribute.name.replace(/([a-z])([A-Z])/g, '$1 $2');  //uncamelcased version
+                return (type.getFieldType(humanName) === undefined);
+            })
         );
         this.features = new Features(type, data);
         this.sections = new Sections(type, data);

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Submission Tool</title>
     <style>
         /* Styles for optimised rendering path */

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -222,9 +222,6 @@ input[readonly], textarea[readonly] {
 .readonly .feature .form-control {
   padding-left: 0;
 }
-.readonly .dropdown:after {
-  display: none;
-}
 
 /* Convenience classes for top-right-corner badge indicators */
 .badge-parent {
@@ -271,4 +268,10 @@ input[readonly], textarea[readonly] {
 }
 .bs-datepicker-body table td span.disabled, .bs-datepicker-body table td.disabled span {
   cursor: default;
+}
+
+//Restores the border radius applied to right corners on fields inside input-groups
+.input-group .subm-field .form-control {
+  border-top-right-radius: @border-radius-base !important;
+  border-bottom-right-radius: @border-radius-base !important;
 }

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -162,10 +162,15 @@
   border-bottom: none;
 }
 
-//Prevents page controls from wrapping onto the next line when on pad-sized screens
+//Prevents page controls from wrapping onto the next line when on smaller screens
 .ag-fresh .ag-paging-row-summary-panel {
   width: auto;
   float: left
+}
+@media screen and (max-width: 650px) {
+  .ag-fresh .ag-paging-row-summary-panel {
+    display: none;
+  }
 }
 .ag-fresh .ag-paging-panel {
   text-align: center;


### PR DESCRIPTION
- Scrolls the submission form enough to position the field pending review alongside its respective sidebar button when this is clicked.
- Counts the number of fields pending review (blurred and still invalid) and changes the background colour of the review counter whenever there is at least one.
- Adds readonly mode for the datepicker.
- Makes the supplementary guidance at the top of the submission form dynamic, according to the state of it (new/invalid/valid).
- Ag-Grid improvements:
  - For the submissions list, prioritises title column for space allocation.
  - Disables the delete button while the corresponding request is ongoing.
  - Fixes the width of some columns like the "Type" colum in the file list.
  - Customises feedback text when list empty. 
- Fixes blank columns in the submissions list and spurious annotations in the submission view by moving some attributes outside the section.
- Disables the delete button when the only the last row of a required feature list is left.
- Makes the submission form tab-friendly and identifies each top-level field or feature with its icon for ease of vertical scanning.
- Makes the submissions view a bit more mobile friendly.
- Adds tooltip for all sidebars' minimise button.
- Removes console.logs not having to do with exceptions or errors.