### PR TITLE
Contact autofill and major refactoring of submissions list and edit views.

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -28,11 +28,42 @@ export class AppConfig {
         return this.config.APP_PROD;
     }
 
+    /**
+     * Synonym getter providing the threshold below which the current screen size will trigger
+     * tablet/mobile-geared layout.
+     * @returns {number} Upper-limit screen size in pixels for tablet-like devices.
+     */
     get tabletBreak(): number {
         return this.config.APP_TABLET_BREAKPOINT;
     }
 
-    // Promise is required here
+    /**
+     * Synonym getter providing the format in which dates should be displayed when listing submissions.
+     * @returns {string} Format expressed in Angular's date pipe notation.
+     * @see {@link https://angular.io/api/common/DatePipe}
+     */
+    get dateListFormat(): string {
+        return this.config.APP_DATE_LIST_FORMAT;
+    }
+
+    /**
+     * Synonym getter providing the format in which dates should be displayed when editing submissions.
+     * @returns {string} Format following the Moment.js' notation.
+     * @see {@link https://momentjs.com/docs/#/parsing/string-format/}
+     */
+    get dateInputFormat(): string {
+        return this.config.APP_DATE_INPUT_FORMAT;
+    }
+
+    /**
+     * Synonym getter providing a flag indicating whether past date selection is allowed.
+     * @returns {boolean} Flag for past date allowance.
+     */
+    get canUsePastDates(): boolean {
+        return this.config.APP_CAN_PAST_DATES;
+    }
+
+    //Promise is required here
     load(): Promise<any> {
         let req: Observable<any> = this.http.get('./config.json');
 

--- a/src/app/auth/signin/signin.component.css
+++ b/src/app/auth/signin/signin.component.css
@@ -1,5 +1,5 @@
 .form-group {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 .text-right {
     font-size: 13px;

--- a/src/app/auth/signin/signin.component.html
+++ b/src/app/auth/signin/signin.component.html
@@ -2,7 +2,7 @@
     <container-md>
         <div class="auth-content">
             <div class="alert" [ngClass]="{'alert-danger': error, 'invisible': !error}">
-                {{error ? error.message.replace('FAIL', '') + '. Please check your credentials and try again.' : '&nbsp;'}}
+                {{error ? error.message.replace('FAIL', '') + '. Please check the fields below and try again.' : '&nbsp;'}}
             </div>
             <h3>Welcome</h3>
             <p>

--- a/src/app/auth/signup/signup.component.html
+++ b/src/app/auth/signup/signup.component.html
@@ -21,9 +21,9 @@
             <div class="panel-body">
                 <form id="signUpForm" novalidate name="signUpForm" role="form"
                       (ngSubmit)="onSubmit(signUpForm)" #signUpForm="ngForm">
-                    <div class="form-group form-group-sm">
+                    <div class="form-group">
                         <label class="control-label" for="username">Full name</label>
-                        <small class="text-muted pull-right"><i>Optional</i></small>
+                        <span class="text-muted pull-right"><i>Optional</i></span>
                         <input type="text" autofocus
                                id="username"
                                name="username"
@@ -46,7 +46,7 @@
                                required
                                validate-onblur>
                     </div>
-                    <div class="form-group form-group-sm" [ngClass]="{'has-error': password.invalid && password.touched}">
+                    <div class="form-group" [ngClass]="{'has-error': password.invalid && password.touched}">
                         <label class="control-label" for="password">
                             <span class="text-black">Password</span>
                             <span *ngIf="password.invalid && password.touched">
@@ -66,7 +66,7 @@
                                minlength="6"
                                #password="ngModel" bsDatepicker/>
                     </div>
-                    <div class="form-group form-group-sm" [ngClass]="{'has-error': orcid.invalid && orcid.touched}">
+                    <div class="form-group" [ngClass]="{'has-error': orcid.invalid && orcid.touched}">
                         <label class="control-label">
                             <span class="text-black">ORCID</span>
                             <span *ngIf="orcid.invalid && orcid.touched">
@@ -74,9 +74,10 @@
                             </span>
                             <span [hidden]="orcid.invalid && orcid.touched" class="text-muted">(should follow dddd-dddd-dddd-dddd format)</span>
                         </label>
-                        <small class="text-muted pull-right"><i>Optional</i></small>
+                        <span class="text-muted pull-right"><i>Optional</i></span>
                         <orcid-input-box
                                 [(ngModel)]="model.orcid"
+                                [isSmall]="false"
                                 name="orcid"
                                 #orcid="ngModel"
                                 validate-onblur>

--- a/src/app/auth/user-data.ts
+++ b/src/app/auth/user-data.ts
@@ -52,13 +52,14 @@ export class UserData {
      * @returns {Object} Object containing contact data.
      */
     get contact(): object {
-        const contact = {};
+        const userData = this;      //gives context to eval op later on
+        const contactObj = {};
 
         Object.keys(UserData.contactMap).forEach((keyToChange) => {
-            contact[UserData.contactMap[keyToChange]] = eval('userData.' + keyToChange);
+            contactObj[UserData.contactMap[keyToChange]] = eval('userData.' + keyToChange);
         });
 
-        return contact;
+        return contactObj;
     }
 
     /**

--- a/src/app/auth/user-data.ts
+++ b/src/app/auth/user-data.ts
@@ -5,54 +5,67 @@ import * as _ from 'lodash';
 import {UserRole} from './user-role';
 import {AuthService} from './auth.service';
 import {UserSession} from './user-session';
+import {Subject} from "rxjs/Subject";
+import {Observable} from "rxjs/Observable";
 
 @Injectable()
 export class UserData {
-    private d: any;
+    static contactMap = {       //maps response property to submission attribute name for contact data
+        'email': 'e-mail',
+        'username': 'name',
+        'aux.orcid': 'orcid'    //allows flattening of nesting levels
+    }
+    private _whenFetched: Subject<any> = new Subject<any>();
+    private isFetched: boolean = false;                         //flags when data has been fetched already
 
-    constructor(userSession: UserSession,
-                authService: AuthService) {
-
+    /**
+     * Waits until the session for the current user has been created to fetch the latter's data.
+     * @param {UserSession} userSession - Async session manager.
+     * @param {AuthService} authService - API interface for athentication-related server transactions
+     */
+    constructor(userSession: UserSession, authService: AuthService) {
         userSession.created$.subscribe(created => {
-            if (created) {
-                this.data = null;
-                authService.checkUser().subscribe(data => {
-                    console.debug('UserData:', data);
-                    this.data = data;
-                });
-            } else {
-                this.data = null;
-            }
+            created && authService.checkUser().subscribe(data => {
+                _.merge(this, data);
+                this._whenFetched.next(data);
+                this.isFetched = true;
+                this._whenFetched.complete();
+            });
+        });
+    }
+
+    /**
+     * Creates an observable normalised to resolve instantly if the user data has already been retrieved.
+     * @returns {Observable<any>} Observable from subject
+     */
+    get whenFetched(): Observable<any> {
+        if (this.isFetched) {
+            return Observable.of(true);     //dummy observable in case user data has already been fetched
+        } else {
+            return this._whenFetched.asObservable();
+        }
+    }
+
+    /**
+     * Creates a new object from the one fetched from the server, changing the names of the properties if so
+     * required.
+     * @returns {Object} Object containing contact data.
+     */
+    get contact(): object {
+        const contact = {};
+
+        Object.keys(UserData.contactMap).forEach((keyToChange) => {
+            contact[UserData.contactMap[keyToChange]] = eval('userData.' + keyToChange);
         });
 
-        this.data = null;
+        return contact;
     }
 
-    get key(): string {
-        return this.data.sessid || '';
-    }
-
-    get name(): string {
-        return this.data.username || '';
-    }
-
-    get email(): string {
-        return this.data.email || '';
-    }
-
-    get orcid(): string {
-        return this.data.aux.orcid || '';
-    }
-
+    /**
+     * Convenience method to determine the user's role (hard-coded for the moment).
+     * @returns {UserRole} - Public.
+     */
     get role(): UserRole {
         return UserRole.Public;
-    }
-
-    private get data(): any {
-        return this.d;
-    }
-
-    private set data(data: any) {
-        this.d = _.assign({aux: {}}, data);
     }
 }

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -22,6 +22,7 @@
                             routerLinkActive="active"
                             tooltip="Register as new user"
                             placement="bottom"
+                            container="body"
                             (click)="toggleCollapsed()">
                         <i class="fa fa-user-plus fa-fw"></i>
                         Register
@@ -32,6 +33,7 @@
                             routerLink="/signin"
                             tooltip="Log in to access studies"
                             placement="bottom"
+                            container="body"
                             (click)="toggleCollapsed()">
                         <i class="fa fa-sign-in"></i>
                         Log in
@@ -44,6 +46,7 @@
                             routerLinkActive="active"
                             tooltip="List of submissions"
                             placement="bottom"
+                            container="body"
                             (click)="toggleCollapsed()">
                         <i class="fa fa-fw fa-table"></i>
                         Submissions
@@ -56,6 +59,7 @@
                             routerLinkActive="active"
                             tooltip="Upload or list your files"
                             placement="bottom"
+                            container="body"
                             (click)="toggleCollapsed()">
                         <i class="fa fa-fw fa-upload"></i>
                         Files
@@ -68,6 +72,7 @@
                             routerLinkActive="active"
                             tooltip="How to use this tool"
                             placement="bottom"
+                            container="body"
                             (click)="toggleCollapsed()">
                         <i class="fa fa-fw fa-question"></i>
                         Help

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -76,13 +76,15 @@
 
                 <li *ngIf="userLoggedIn">
                     <button class="btn navbar-btn"
-                            (click)="signOut()">
-                        <i class="fa fa-fw fa-sign-out"></i>
+                            (click)="signOut()"
+                            [disabled]="isBusy">
+                        <i *ngIf="!isBusy" class="fa fa-fw fa-sign-out"></i>
+                        <i *ngIf="isBusy" class="fa fa-fw fa-cog fa-spin"></i>
                         Log out
                     </button>
                 </li>
             </ul>
         </div>
     </div>
-    <div class="loading-bar" [ngClass]="{'animate': isLoaderVisible}"></div>
+    <div class="loading-bar" [ngClass]="{'animate': isPendingReq}"></div>
 </nav>

--- a/src/app/shared/confirm-dialog.component.ts
+++ b/src/app/shared/confirm-dialog.component.ts
@@ -33,7 +33,7 @@ export class ConfirmDialogComponent {
     /**
      * Renders the confirmation modal, allowing subscription to button events.
      * @param {string} [message] - Optional text for the modal's body section.
-     * @param {boolean} [isDiscardCancel] - Optional RxJS stream behaviour. By default,
+     * @param {boolean} [isDiscardCancel = true] - Optional RxJS stream behaviour. By default,
      * events are assumed to come from the confirmation button exclusively.
      * @returns {Observable<any>} Stream of button events.
      */

--- a/src/app/shared/inline-edit.component.html
+++ b/src/app/shared/inline-edit.component.html
@@ -6,14 +6,14 @@
            [placeholder]="placeholder"
            (blur)="onEditBoxBlur($event)"
            (keyup)="onEditBoxKeyUp($event)"
-           (click)="canEdit && onEditClick()"
+           (click)="canEdit && startEditing()"
            [readonly]="!editing"
            name="inline-edit-box"
            #inlineEditBox/>
     <div *ngIf="!editing" class="icons">
         <button class="btn btn-xs btn-link"
                 *ngIf="canEdit"
-                (click)="onEditClick()">
+                (click)="startEditing()">
             <i class="fa fa-pencil"></i>
         </button>
         <button class="btn btn-xs btn-link"

--- a/src/app/shared/inline-edit.component.ts
+++ b/src/app/shared/inline-edit.component.ts
@@ -3,10 +3,7 @@ import {
     Input,
     Output,
     forwardRef,
-    EventEmitter,
-    ViewChildren,
-    QueryList,
-    ElementRef, AfterViewInit
+    EventEmitter
 } from '@angular/core';
 
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
@@ -21,7 +18,7 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 })
 export class InlineEditComponent implements ControlValueAccessor {
     @Input() required?: boolean = false;
-    @Input() disabled?: boolean = false;
+    @Input() disableEdit?: boolean = false;
     @Input() emptyValue?: string = '';
     @Input() placeholder?: string = '';
     @Output() remove: EventEmitter<any> = new EventEmitter<any>();
@@ -56,7 +53,7 @@ export class InlineEditComponent implements ControlValueAccessor {
     }
 
     private get canEdit(): boolean {
-        return !this.required;
+        return !this.required && !this.disableEdit;
     }
 
     private startEditing(): void {
@@ -65,13 +62,6 @@ export class InlineEditComponent implements ControlValueAccessor {
 
     private stopEditing(): void {
         this.editing = false;
-    }
-
-    private onEditClick(ev): void {
-        if (this.disabled) {
-            return;
-        }
-        this.startEditing();
     }
 
     private onRemoveClick(ev): void {

--- a/src/app/shared/orcid-input-box.component.html
+++ b/src/app/shared/orcid-input-box.component.html
@@ -1,14 +1,17 @@
-<div class="input-group">
+<div [ngClass]="{'input-group': isPopupButton}">
+    <span *ngIf="isPopupButton" class="input-group-btn">
+        <button class="btn btn-sm btn-primary" type="button"
+                [ngClass]="{'btn-sm': isSmall}"
+                (click)="openPopup()">
+            <i class="fa fa-external-link" aria-hidden="true"></i>
+        </button>
+    </span>
     <input type="text"
            class="form-control"
+           [ngClass]="{'input-sm': isSmall}"
            [(ngModel)]="value"
            (blur)="onBlur()"
            pattern="\d{4}-\d{4}-\d{4}-\d{4}"
            placeholder="e.g. 1892-5647-2571-9436"
            #inputModel="ngModel">
-    <span class="input-group-btn">
-        <button class="btn btn-sm btn-primary" type="button" (click)="openPopup()">
-            <i class="fa fa-external-link" aria-hidden="true"></i>
-        </button>
-    </span>
 </div>

--- a/src/app/shared/orcid-input-box.component.ts
+++ b/src/app/shared/orcid-input-box.component.ts
@@ -1,7 +1,7 @@
 import {
     Component,
     forwardRef,
-    Injector,
+    Injector, Input,
     ViewChild
 } from '@angular/core';
 
@@ -35,6 +35,9 @@ export class ORCIDInputBoxComponent implements ControlValueAccessor {
     private orcidValue = '';                    //internal data model
     private mlistener = null;
 
+    @Input() isPopupButton: boolean = true;     //flag for showing/hiding popup button
+    @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
+
     @ViewChild('inputModel')
     private inputModel:NgModel;
 
@@ -49,19 +52,19 @@ export class ORCIDInputBoxComponent implements ControlValueAccessor {
         return this.orcidValue;
     }
 
-    set value(value) {
-        this.orcidValue = value;
-        this.onChange(value);
+    set value(newValue) {
+        this.orcidValue = newValue;
+        this.onChange(newValue);
     }
 
     /**
      * Writes a new value from the form model into the view or (if needed) DOM property.
      * @see {@link ControlValueAccessor}
-     * @param value - Value to be stored
+     * @param newValue - Value to be stored
      */
-    writeValue(value: any) {
-        if (value) {
-            this.orcidValue = value;
+    writeValue(newValue: any) {
+        if (newValue) {
+            this.orcidValue = newValue;
         }
     }
 

--- a/src/app/submission-shared/file-input.component.html
+++ b/src/app/submission-shared/file-input.component.html
@@ -1,14 +1,18 @@
-<select  *ngIf="files.length > 0"
+<select  *ngIf="files.length > 0 && !readonly"
          class="form-control input-sm"
          [name]="name"
          [(ngModel)]="value"
-         [required]="required"
-         [disabled]="readonly">
+         [required]="required">
     <option *ngFor="let file of files" [value]="file">{{file}}</option>
 </select>
-<a *ngIf="files.length == 0" class="form-control input-sm no-files"
+<a *ngIf="files.length == 0 && !readonly" class="form-control input-sm no-files"
    routerLink="/files"
    [queryParams]="{bb: true}">
     Upload a file
     <i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
 </a>
+<input *ngIf="readonly"
+       class="form-control input-sm"
+       [name]="name"
+       [ngModel]="(files.length > 0 && isFound) ? value : 'File not found'"
+       readonly>

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.html
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.html
@@ -27,7 +27,7 @@
               #uploadForm="ngForm">
 
             <div class="form-group">
-                <label>Data file</label>
+                <label class="control-label">Data file</label>
                 <file-upload-button class="show"
                                     title="Select file"
                                     (select)="onUploadFilesSelect($event)"></file-upload-button>
@@ -35,7 +35,7 @@
             </div>
 
             <div class="form-group">
-                <label for="">File format</label>
+                <label class="control-label">File format</label>
                 <select name="formatSelect"
                         class="form-control"
                         [(ngModel)]="model.format">
@@ -45,7 +45,7 @@
                 </select>
             </div>
             <div class="form-group">
-                <label for="">Attach to project</label>
+                <label class="control-label">Attach to project</label>
                 <ul *ngIf="model.projects.length > 0">
                     <li *ngFor="let p of model.projects">{{p}}</li>
                 </ul>

--- a/src/app/submission/edit/subm-add/subm-add.component.html
+++ b/src/app/submission/edit/subm-add/subm-add.component.html
@@ -13,16 +13,6 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    <div class="form-group">
-                        <label class="control-label">Type</label>
-                        <select class="form-control"
-                                [(ngModel)]="type"
-                                name="type">
-                            <option value="List">List</option>
-                            <option value="Grid">Grid</option>
-                            <option value="Section">Section</option>
-                        </select>
-                    </div>
                     <div class="form-group"[ngClass]="{'has-error': (typeName.invalid || !isUnique) && typeName.touched}">
                         <label class="control-label" for="typeName">
                             <span class="text-black">Name</span>
@@ -42,6 +32,16 @@
                                validate-onblur
                                required
                                autofocus #focusBtn>
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label">Type</label>
+                        <select class="form-control"
+                                [(ngModel)]="type"
+                                name="type">
+                            <option value="List">List</option>
+                            <option value="Grid">Grid</option>
+                            <option value="Section">Section</option>
+                        </select>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/src/app/submission/edit/subm-add/subm-add.component.ts
+++ b/src/app/submission/edit/subm-add/subm-add.component.ts
@@ -18,7 +18,7 @@ import {
 })
 export class SubmAddDialogComponent implements AfterViewInit {
     private _type: string;       //form model member for the type property
-    name: string;                //form model member for the name property
+    name: string;                //form model member for the new type's name property
     isUnique: boolean;           //uniqueness flag of the chosen type name
 
     @Input() onAddType: Function = () => {}; //callback for add action (acts as an ad-hoc, async validator)
@@ -95,8 +95,7 @@ export class SubmAddDialogComponent implements AfterViewInit {
     /**
      * Shows validation errors globally on submission according to the nature of the type, using the addition operation
      * as a validator post-submission. Only after that op is the form data confirmed as valid.
-     * modal is simply
-     * @param {NgForm} form
+     * @param {NgForm} form New type submit form.
      */
     onSubmit(form: NgForm): void {
         let isSingleRow: boolean = false;

--- a/src/app/submission/edit/subm-edit.component.html
+++ b/src/app/submission/edit/subm-edit.component.html
@@ -1,5 +1,5 @@
 <div class="row-offcanvas row-offcanvas-left"
-     [ngClass]="{'readonly': readonly, 'disabled': isReverting}">
+     [ngClass]="{'readonly': readonly, 'grayout': isReverting}">
     <subm-sidebar *ngIf="!readonly"
                   (toggle)="sideBarCollapsed=!sideBarCollapsed"
                   [collapsed]="sideBarCollapsed"
@@ -114,6 +114,9 @@
                     <p class="col-xs-2">
                         <button type="button" class="btn-submit btn btn-primary"
                                 [disabled]="isSubmitting || isSaving"
+                                tooltip="Send to the BioStudies database"
+                                placement="top"
+                                container="body"
                                 (click)="onSubmit($event)">
                             {{subm.isTemp ? 'S' : 'Re-s'}}ubmit
                         </button>
@@ -125,6 +128,9 @@
                     </p>
                     <p class="col-xs-2 text-right">
                         <button *ngIf="!readonly && errors && !errors.empty()" class="btn btn-default btn-sm btn-log"
+                                tooltip="Show validation log"
+                                placement="left"
+                                container="body"
                                 (click)="onViewLog($event)">
                             View log
                         </button>

--- a/src/app/submission/edit/subm-edit.component.html
+++ b/src/app/submission/edit/subm-edit.component.html
@@ -1,5 +1,5 @@
 <div class="row-offcanvas row-offcanvas-left"
-     [ngClass]="{'readonly': readonly}">
+     [ngClass]="{'readonly': readonly, 'disabled': isReverting}">
     <subm-sidebar *ngIf="!readonly"
                   (toggle)="sideBarCollapsed=!sideBarCollapsed"
                   [collapsed]="sideBarCollapsed"
@@ -12,9 +12,11 @@
             [ngClass]="{'collapse-left': !readonly && sideBarCollapsed}"
             [readonly]="readonly"
             [accno]="accno"
-            [errors]="errors"
+            [isTemp]="subm?.isTemp"
+            [isRevised]="subm?.isRevised"
             [sectionPath]="sectionPath"
             (sectionClick)="onSectionClick($event)"
+            (revertClick)="onRevert($event)"
             (submitClick)="onSubmit($event)">
     </subm-navbar>
 
@@ -28,11 +30,10 @@
                     <div class="panel-body">
                         <h4>New submission</h4>
                         <p>
-                            Please fill out the form below. All fields are required unless marked as <i>Optional</i>. The
-                            <span class="font-bold">Review</span> tab on the
-                            left-hand side lists any missing or invalid information, while the
-                            <span class="font-bold">Types</span> tab contains
-                            optional field types that may be added to this submission.
+                            Please fill in the form below. All fields are required unless marked as <i>Optional</i>.<br>
+                            The <span class="font-bold">Check</span> tab on the
+                            left-hand side lists those form fields still incomplete or incorrect. Use the
+                            <span class="font-bold">Add</span> tab to quickly add new rows or tables.
                         </p>
                     </div>
                 </div>
@@ -42,19 +43,39 @@
                         <h4>Incomplete submission</h4>
                         <p>
                             Some information in this submission is still missing or incorrect. Please
-                            note that all fields are required unless marked as <i>Optional</i>. Check the
-                            <span class="font-bold">Review</span> tab on the left-hand side for more help.
+                            note that all fields are required unless marked as <i>Optional</i>. You can find the list
+                            of fields that need updating under the <span class="font-bold">Check</span> tab on the
+                            left-hand side.
                         </p>
                     </div>
                 </div>
 
-                <div *ngIf="!errors.total() && !readonly" class="panel">
+                <div *ngIf="!errors.total() && !readonly">
+                    <div *ngIf="subm.isTemp" class="panel">
+                        <div class="panel-body">
+                            <h4>Study ready for submission</h4>
+                            <p>
+                                You may submit the data on this form now. After submission, your study will be allocated
+                                a permanent accession number under which it will be published.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div *ngIf="!subm.isTemp" class="panel">
+                        <div class="panel-body">
+                            <h4>Study ready for re-submission</h4>
+                            <p>
+                                You may re-submit the data on this form now. Your study will retain
+                                the same accession number under which it was published.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div *ngIf="!subm.isTemp && readonly" class="panel">
                     <div class="panel-body">
-                        <h4>Study ready for submission</h4>
-                        <p>
-                            You may submit the data on this form now. After submission, your study will be allocated
-                            a permanent accession number under which it will be published.
-                        </p>
+                        <h4>Submitted study</h4>
+                        <p>The study has been added to the BioStudies database with accession number <strong>{{accno}}</strong>.</p>
                     </div>
                 </div>
 
@@ -64,8 +85,8 @@
                            [readonly]="readonly">
                 </subm-form>
 
-                <div class="list-group">
-                    <label class="control-label" *ngIf="section.sections.list().length > 0">Subsections</label>
+                <div *ngIf="section.sections.list().length > 0" class="list-group form-group">
+                    <label class="control-label">Sections</label>
                     <div *ngFor="let subsection of section.sections.list()"
                           class="list-group-item">
                         {{subsection.typeName}}
@@ -90,25 +111,36 @@
                 </div>
 
                 <div *ngIf="!readonly" class="row row-submit">
-                    <p class="col-md-2">
-                        <button type="button" class="btn-submit btn btn-primary col-md-12"
+                    <p class="col-xs-2">
+                        <button type="button" class="btn-submit btn btn-primary"
                                 [disabled]="isSubmitting || isSaving"
                                 (click)="onSubmit($event)">
-                            Submit
+                            {{subm.isTemp ? 'S' : 'Re-s'}}ubmit
                         </button>
                     </p>
-                    <p class="text-muted col-md-10">
+                    <p class="text-muted col-xs-9">
                         <i class="fa fa-cog fa-spin" *ngIf="isSubmitting || isSaving"></i>
                         <span *ngIf="isSubmitting">Submitting study...</span>
                         <span *ngIf="isSaving">Backing up study data...</span>
                     </p>
+                    <p class="col-xs-2 text-right">
+                        <button *ngIf="!readonly && errors && !errors.empty()" class="btn btn-default btn-sm btn-log"
+                                (click)="onViewLog($event)">
+                            View log
+                        </button>
+                    </p>
                 </div>
             </div>
         </aside>
-        <confirm-dialog #confirmDialog
+        <confirm-dialog #confirmSectionDel
                         headerTitle="Delete section"
                         body="You are about to permanently delete the section"
                         confirmLabel="Delete">
+        </confirm-dialog>
+        <confirm-dialog #confirmRevert
+                        headerTitle="Revert to released version"
+                        confirmLabel="Revert"
+                        body="You are about to discard all changes made to this submission since it was last released. This operation cannot be undone.">
         </confirm-dialog>
     </div>
 </div>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -15,7 +15,8 @@
                     emptyValue="{{'Column ' + (idx + 1)}}"
                     (remove)="feature.removeColumn(column.id)"
                     [formControl]="featureForm.columnControl(column.id)"
-                    [required]="column.required">
+                    [required]="column.required"
+                    [disableEdit]="featureForm.columnType(column.id).displayed || readonly">
             </inline-edit>
         </div>
     </div>
@@ -43,6 +44,7 @@
                             [type]="column.valueType"
                             [(ngModel)]="row.valueFor(column.id).value"
                             [readonly]="readonly"
+                            [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
                             isSmall="true"
                             validate-onblur>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -29,6 +29,7 @@
                     [disabled]="!feature.canRemoveRowAt(index)"
                     (click)="feature.removeRowAt(rowIdx)"
                     [tooltip]="'Delete ' + feature.typeName.toLowerCase() + ' ' + (rowIdx + 1)"
+                    placement="bottom"
                     container="body">
                 <i class="fa fa-trash"></i>
             </button>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -7,7 +7,8 @@
         <div class="cell col-xs-3">
             <div class="form-group key-field">
                 <div class="input-group">
-                    <span *ngIf="!readonly && !column.required" class="input-group-btn">
+                    <span *ngIf="!readonly && !column.required && !featureForm.columnType(column.id).displayed"
+                          class="input-group-btn">
                           <button type="button" tabindex="-1"
                                   class="btn btn-sm btn-danger btn-flat"
                                   (click)="featureForm.feature.removeRowAt(idx)"
@@ -18,10 +19,9 @@
                     </span>
                     <input type="text"
                            class="form-control input-sm"
-                           [readonly]="readonly"
                            [(ngModel)]="column.name"
                            [formControl]="featureForm.columnControl(column.id)"
-                           [readonly]="column.required || readonly"
+                           [readonly]="readonly || column.required || featureForm.columnType(column.id).displayed"
                            (blur)="featureForm.columnControl(column.id).value ||
                                    featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
                 </div>
@@ -38,6 +38,7 @@
                             [type]="column.valueType"
                             [(ngModel)]="feature.rows[0].valueFor(column.id).value"
                             [readonly]="readonly"
+                            [required]="column.required"
                             isSmall="true"
                             [formControl]="featureForm.rowValueControl(0,column.id)"
                             validate-onblur>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -13,7 +13,9 @@
                                   class="btn btn-sm btn-danger btn-flat"
                                   (click)="featureForm.feature.removeRowAt(idx)"
                                   [disabled]="!feature.canRemoveRowAt(idx)"
-                                  [tooltip]="'Delete ' + feature.typeName.toLowerCase() + ' entry'">
+                                  [tooltip]="'Delete &quot;' + column.name + '&quot; entry'"
+                                  placement="bottom"
+                                  container="body">
                                <i class="fa fa-trash-o"></i>
                           </button>
                     </span>
@@ -53,6 +55,7 @@
                 type="button"
                 class="btn-add btn btn-link"
                 [tooltip]="'Add a new ' + feature.typeName.toLowerCase()"
+                container="body"
                 (click)="feature.addColumn()">
             <i class="fa fa-lg {{feature.type.icon}}"></i>
             &nbsp;Add {{feature.typeName.toLowerCase()}} row

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.css
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.css
@@ -1,8 +1,13 @@
+.panel {
+    margin-bottom: 0;
+}
 .panel-heading .fa {
     color: #777777;
+    vertical-align: middle;
 }
 .panel-description {
     display: inline-block;
     margin: 0 .5rem;
     width: 83%;
+    vertical-align: middle;
 }

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -1,5 +1,5 @@
 <strong class="text-danger" *ngIf="errorNum && feature.size() > 0">Please review the fields below</strong>
-<div *ngIf="feature.size() > 0" class="panel panel-default feature">
+<div class="panel panel-default feature">
 
     <div *ngIf="!readonly" class="panel-heading clearfix">
         <div *ngIf="isMenu" class="btn-toolbar pull-left" role="toolbar">

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -22,14 +22,16 @@ export class SubmFeatureComponent implements OnInit {
     actions: any[] = [];
     errorNum: number = 0;
 
+
     constructor(private changeRef: ChangeDetectorRef) {}
 
     ngOnInit() {
+
+        //Defines the actions of the feature's menu according to its type (list or not).
         this.actions.push({
             label: 'Add column',
             invoke: () => this.feature.addColumn()
         });
-
         if (!this.feature.singleRow) {
             this.actions.push({
                 label: 'Add row',

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -12,7 +12,6 @@
            typeaheadMinLength="0"
            typeaheadOptionsLimit="30"
 -->
-
 <date-input
         *ngIf="type === 'date'"
         [(ngModel)]="value"
@@ -20,6 +19,15 @@
         [readonly]="readonly"
         (focusout)="onBlur()">
 </date-input>
+
+<!-- TODO: Template-driven validation for ORCID is not bubbling up to the reactive form control wrapping it -->
+<orcid-input-box
+        *ngIf="type === 'orcid'"
+        [isSmall]="isSmall"
+        [required]="required"
+        [isPopupButton]="false"
+        [(ngModel)]="value">
+</orcid-input-box>
 
 <file-input *ngIf="type === 'file'"
             [(ngModel)]="value"

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -2,12 +2,13 @@ import {
     Component,
     Input,
     forwardRef,
-    ElementRef
+    ElementRef, ViewChild
 } from '@angular/core';
 
 import {
+    AsyncValidator,
     ControlValueAccessor,
-    NG_VALUE_ACCESSOR,
+    NG_VALUE_ACCESSOR, NgModel, Validators,
 } from '@angular/forms';
 import {FieldControl} from "../subm-form.service";
 
@@ -25,14 +26,14 @@ export class SubmFieldComponent implements ControlValueAccessor {
     private onChange: any = (_:any) => {};      //placeholder for handler propagating changes outside the custom control
     private onTouched: any = () => {};          //placeholder for handler after the control has been "touched"
 
+    private _value = '';
+
     @Input() name: string;
     @Input() type: string;
-    @Input() isSmall: boolean;
     @Input() readonly: boolean;
     @Input() required: boolean;
     @Input() formControl: FieldControl;
-
-    private _value = '';
+    @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
 
     constructor(private elementRef: ElementRef) { }
 
@@ -43,10 +44,6 @@ export class SubmFieldComponent implements ControlValueAccessor {
     set value(value) {
         this._value = value;
         this.onChange(value);
-    }
-
-    ngAfterViewInit(): void {
-        this.formControl.nativeElement = this.elementRef.nativeElement.querySelector('.form-control');
     }
 
     /**
@@ -83,5 +80,13 @@ export class SubmFieldComponent implements ControlValueAccessor {
      */
     onBlur() {
         this.onTouched();
+    }
+
+    /**
+     * Lifecycle hook for operations after all child views have been initialised.
+     * Updates the pointer to the DOM element too.
+     */
+    ngAfterViewInit(): void {
+        this.formControl.nativeElement = this.elementRef.nativeElement.querySelector('.form-control');
     }
 }

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -4,18 +4,32 @@
 
     <div *ngFor="let field of sectionForm.fields"
          class="form-group row">
-        <div class="col-sm-12"
-             [ngClass]="{'has-error': sectionForm.fieldControl(field.id).invalid && sectionForm.fieldControl(field.id).touched}">
+        <div class="col-xs-12"
+             [ngClass]="{'has-error': get(field.id).invalid && get(field.id).touched}">
             <label class="control-label">
                 <span class="text-black">{{field.name}}</span>
-                <span *ngIf="sectionForm.fieldControl(field.id).invalid && sectionForm.fieldControl(field.id).touched">
+                <span *ngIf="get(field.id).invalid && get(field.id).touched">
                     {{sectionForm.formErrors[field.id] ? sectionForm.formErrors[field.id] : ''}}
                 </span>
-                <small *ngIf="!readonly && !field.type.required" class="text-muted pull-right"><i>Optional</i></small>
+                <span [hidden]="readonly || get(field.id).invalid && get(field.id).touched" class="text-muted">
+                     <span *ngIf="(get(field.id, 'minlength') > 0) && (get(field.id, 'maxlength') < 0)">
+                         (at least {{get(field.id, 'minlength')}}
+                     </span>
+                     <span *ngIf="(get(field.id, 'minlength') < 0) && (get(field.id, 'maxlength') > 0)">
+                         (at most {{get(field.id, 'maxlength')}}
+                     </span>
+                     <span *ngIf="(get(field.id, 'minlength') > 0) && (get(field.id, 'maxlength') > 0)">
+                         (between {{get(field.id, 'minlength')}} and {{get(field.id, 'maxlength')}}
+                     </span>
+                     <span *ngIf="(get(field.id, 'minlength') > 0) || (get(field.id, 'maxlength') > 0)">
+                         characters long)
+                     </span>
+                </span>
             </label>
-            <div class="input-group">
-                <span class="input-group-addon">
-                    <i class="fa {{sectionForm.fieldControl(field.id).parentType.icon}}"></i>
+            <span *ngIf="!readonly && !field.type.required" class="text-muted pull-right"><i>Optional</i></span>
+            <div [ngClass]="{'input-group': !readonly}">
+                <span *ngIf="!readonly" class="input-group-addon">
+                    <i class="fa {{get(field.id, 'icon')}}"></i>
                 </span>
                 <subm-field class="subm-field"
                     [type]="field.valueType"
@@ -23,21 +37,22 @@
                     [readonly]="readonly"
                     [required]="field.type.required"
                     [(ngModel)]="field.value"
-                    [formControl]="sectionForm.fieldControl(field.id)"
+                    [formControl]="get(field.id)"
                     validate-onblur>
                 </subm-field>
             </div>
         </div>
     </div>
 
-    <div *ngFor="let feature of sectionForm.features">
-        <span *ngIf="feature.size() > 0">
+    <div *ngFor="let feature of sectionForm.features"
+        [ngClass]="{'form-group row': feature.size() > 0}">
+        <div *ngIf="feature.size() > 0" class="col-xs-12">
             <label class="control-label">{{feature.pluralName()}}</label>
-            <small *ngIf="!readonly && !feature.type.required" class="text-muted pull-right"><i>Optional</i></small>
-        </span>
-        <subm-feature [isMenu]="false"
-                      [featureForm]="sectionForm.featureForm(feature.id)"
-                      [readonly]="readonly">
-        </subm-feature>
+            <span *ngIf="!readonly && !feature.type.required" class="text-muted pull-right"><i>Optional</i></span>
+            <subm-feature [isMenu]="false"
+                          [featureForm]="sectionForm.featureForm(feature.id)"
+                          [readonly]="readonly">
+            </subm-feature>
+        </div>
     </div>
 </form>

--- a/src/app/submission/edit/subm-form/subm-form.component.ts
+++ b/src/app/submission/edit/subm-form/subm-form.component.ts
@@ -6,7 +6,7 @@ import {
 
 import {
     SubmFormService,
-    SectionForm
+    SectionForm, FieldControl
 } from './subm-form.service';
 
 import {Section} from '../../shared/submission.model';
@@ -26,5 +26,22 @@ export class SubmFormComponent implements OnChanges {
 
     ngOnChanges(): void {
         this.sectionForm = this.submFormService.createForm(this.section);
+    }
+
+    /**
+     * Convenience method to retrieve the control corresponding to a certain top-level field.
+     * Optionally, it can also fetch the value of a certain attribute within the type assigned to that field.
+     * @param {string} fieldId - ID for the field to be retrieved.
+     * @param {string} [typeAttr = ''] - Name of the type attribute to be retrieved.
+     * @returns {FieldControl} - Extended form control for the field.
+     */
+    get(fieldId: string, typeAttr?: string | ''): FieldControl | any {
+        const fieldControl = this.sectionForm.fieldControl(fieldId);
+
+        if (typeAttr) {
+            return fieldControl.parentType[typeAttr];
+        } else {
+            return fieldControl;
+        }
     }
 }

--- a/src/app/submission/edit/subm-form/subm-form.service.ts
+++ b/src/app/submission/edit/subm-form/subm-form.service.ts
@@ -197,8 +197,8 @@ export class SectionForm {
         FieldControl.toArray(this.featuresFormGroup, controls);
     }
 
-    fieldControl(fieldId: string): FormControl {
-        return <FormControl>this.fieldsFormGroup.get(fieldId);
+    fieldControl(fieldId: string): FieldControl {
+        return <FieldControl>this.fieldsFormGroup.get(fieldId);
     }
 
     featureForm(featureId: string): FeatureForm {

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.html
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.html
@@ -1,15 +1,15 @@
 <div class="col-xs-8 col-md-9">
-    <a *ngIf="!readonly" routerLink="/submissions">
-        <i class="fa fa-clock-o" aria-hidden="true"></i> Temporary
+    <a *ngIf="isTemp" routerLink="/submissions">
+        <i class="fa fa-clock-o" aria-hidden="true"></i> Pending
     </a>
-    <a *ngIf="readonly" routerLink="/submissions/sent">
+    <a *ngIf="!isTemp" routerLink="/submissions/sent">
         <i class="fa fa-database" aria-hidden="true"></i> Sent
     </a>
     <span *ngFor="let sec of sectionPath; let idx = index; let last = last;">
         &nbsp;<i class="fa fa-angle-right font-bold"></i>&nbsp;
         <a href="javascript:void(0)" (click)="onSectionClick(sec)">
             <span [ngClass]="{'current-section': last}">
-                <span *ngIf="idx == 0">{{accno}}</span>
+                <span *ngIf="idx == 0">{{accno}}{{isDiscardable? ' (revised)' : ''}}</span>
                 <span *ngIf="idx > 0">{{sec.typeName}}</span>
             </span>
         </a>
@@ -18,11 +18,12 @@
 --><div class="col-xs-4 col-md-3 btn-toolbar">
     <button *ngIf="!readonly" class="button-link btn btn-primary btn-sm btn-submit pull-right"
             (click)="onSubmit($event)">
-        Submit
+        {{isTemp ? 'S' : 'Re-s'}}ubmit
     </button>
-    <button *ngIf="!readonly && errors && !errors.empty()" class="button-link btn btn-default btn-sm pull-right"
-            (click)="onErrorsLabelClick($event)">
-        View log
+    <button  *ngIf="!readonly && !isTemp && isRevised" class="button-link btn btn-primary btn-sm btn-danger pull-right"
+            (click)="onRevert($event)">
+        <i class="fa fa-undo" aria-hidden="true"></i>
+        Revert
     </button>
     <button *ngIf="readonly" class="button-link btn btn-primary btn-sm pull-right"
             (click)="createSubmission()">

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.html
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.html
@@ -17,10 +17,16 @@
 </div><!--
 --><div class="col-xs-4 col-md-3 btn-toolbar">
     <button *ngIf="!readonly" class="button-link btn btn-primary btn-sm btn-submit pull-right"
+            tooltip="Send to the BioStudies database"
+            placement="{{isRevised ? 'bottom' : 'left'}}"
+            container="body"
             (click)="onSubmit($event)">
         {{isTemp ? 'S' : 'Re-s'}}ubmit
     </button>
     <button  *ngIf="!readonly && !isTemp && isRevised" class="button-link btn btn-primary btn-sm btn-danger pull-right"
+             tooltip="Revert to last released version"
+             placement="bottom"
+             container="body"
             (click)="onRevert($event)">
         <i class="fa fa-undo" aria-hidden="true"></i>
         Revert

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.ts
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.ts
@@ -2,16 +2,15 @@ import {
     Component,
     Input,
     Output,
-    EventEmitter
+    EventEmitter, ViewChild
 } from '@angular/core';
 import {Router} from "@angular/router";
-import {BsModalService} from "ngx-bootstrap/modal";
 
 import {Section} from '../../shared/submission.model';
-import {SubmValidationErrorsComponent} from './subm-validation-errors.component';
-import {SubmValidationErrors} from '../../shared/submission.validator';
 import {SubmissionService} from "../../shared/submission.service";
 import {PageTab} from "app/submission/shared/pagetab.model";
+import {ConfirmDialogComponent} from "../../../shared/confirm-dialog.component";
+import {Observable} from "rxjs/Observable";
 
 @Component({
     selector: 'subm-navbar',
@@ -21,26 +20,25 @@ import {PageTab} from "app/submission/shared/pagetab.model";
 export class SubmNavBarComponent {
     @Input() accno: string;
     @Input() readonly: boolean;
-    @Input() errors: SubmValidationErrors = SubmValidationErrors.EMPTY;
+    @Input() isTemp: boolean;
     @Input() sectionPath: Section[];
-
+    @Input() isRevised: boolean;
     @Output() sectionClick: EventEmitter<Section> = new EventEmitter<Section>();
-    @Output() submitClick: EventEmitter<Section> = new EventEmitter<Section>();
+    @Output() revertClick: EventEmitter<Event> = new EventEmitter<Event>();
+    @Output() submitClick: EventEmitter<Event> = new EventEmitter<Event>();
 
-    constructor(private modalService: BsModalService,
-                private submService: SubmissionService,
+    constructor(private submService: SubmissionService,
                 private router: Router) {}
 
-    onSectionClick(ev: Section): void {
-        this.sectionClick.next(ev);
+    onSectionClick(section: Section): void {
+        this.sectionClick.next(section);
     }
 
-    onErrorsLabelClick(ev): void {
-        const bsModalRef = this.modalService.show(SubmValidationErrorsComponent);
-        bsModalRef.content.errors = this.errors;
+    onRevert(event: Event): void {
+        this.revertClick.next(event);
     }
 
-    onSubmit(event): void {
+    onSubmit(event: Event): void {
         this.submitClick.next(event);
     }
 

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.css
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.css
@@ -2,7 +2,7 @@
     padding: 12px 10px 12px 10px;
 }
 
-/* Types tab - list mode */
+/* Add tab - list mode */
 .sidebar-item {
     line-height: 30px;
 }
@@ -16,11 +16,15 @@
 .sidebar-item.type-control a {
     color: #317181;
 }
-.sidebar-item.type-control a:hover {
+.sidebar-item.type-control a:hover, .advanced-btn {
     color: #fff;
 }
 .sidebar-item.type-control a:hover .fa-inverse {
     color: #3c8b9f;
+}
+.advanced-btn {
+    outline: none !important;
+    text-decoration: none;
 }
 .fa-lg {
     vertical-align: middle;
@@ -30,7 +34,19 @@
     font-size: 12px;
 }
 
-/* Types tab - edit mode */
+/* Advanced submenu */
+.advanced-menu {
+    max-height: 200px;
+    overflow: hidden;
+    -webkit-transition: max-height .3s ease-in;
+    -moz-transition: max-height .3s ease-in;
+    transition: max-height .3s ease-in;
+}
+.collapsed-box {
+    max-height: 0;
+}
+
+/* Add tab - edit mode */
 .edit-type-form {
     background: #fff;
 }
@@ -56,7 +72,7 @@
     color: #3c8b9f;
 }
 
-/* Review tab */
+/* Check tab */
 .no-error-msg {
     position: absolute;
     top: 50%;
@@ -69,7 +85,7 @@
 .collapse-left .no-error-msg {
     width: 100%;
 }
-.collapse-left .no-error-msg h4 {
+.collapse-left .no-error-msg .action-title {
     display: none;
 }
 .label {

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -27,15 +27,16 @@
     </div>
     <ul class="sidebar-menu">
 
-        <!-- Types tab -->
+        <!-- Add tab -->
         <form novalidate
               [ngClass]="{'edit-type-form': editing}"
               #form="ngForm"
               (ngSubmit)="onSubmit(form)">
             <li class="sidebar-item" *ngFor="let item of items; let i = index">
-                <a *ngIf="!isStatus && !editing" (click)="item.onClick($event)"
-                   [tooltip]="item.label"
-                   container="body">
+                <a *ngIf="!isStatus && !editing"
+                   tooltip="Add to the form"
+                   container="body"
+                   (click)="item.onClick($event)">
                     <i class="fa fa-lg text-center {{item.feature.type.icon}}"></i>
                     {{!collapsed ? '&nbsp;&nbsp;' + item.feature.typeName + ' ' + addUnit(item.feature.size()) : ''}}
                 </a>
@@ -110,7 +111,7 @@
             </ul>
         </li>
 
-        <!-- Review tab -->
+        <!-- Check tab -->
         <div *ngIf="isStatus">
             <li *ngIf="errors.empty()" class="no-error-msg text-center"
                 [ngClass]="{'col-md-12': !collapsed}">
@@ -121,9 +122,9 @@
             </li>
             <li class="sidebar-item" *ngFor="let control of formControls; let i = index">
                 <a *ngIf="control.invalid"
-                   tooltip="{{collapsed ? '&quot;' + control.template.name + '&quot; field is ' + tipText(control.errors) : ''}}"
+                   tooltip="{{collapsed ? '&quot;' + control.template.name + '&quot; field is ' + tipText(control.errors) : 'Scroll field into view'}}"
                    container="body"
-                   placement="right"
+                   placement="{{collapsed ? 'right' : 'top'}}"
                    (click)="onReviewClick($event, control)">
                     <i class="fa fa-lg text-center {{control.parentType.icon}}"></i>
                     {{!collapsed ? '&nbsp;' + control.template.name + '&nbsp;' : ''}}

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -3,7 +3,7 @@
     <div class="menu-toggle">
         <button class="minimise-btn btn pull-right"
                 [ngClass]="{'inactive': !collapsed}"
-                (click)="onToggle($event)"
+                (click)="onToggleCollapse($event)"
                 tooltip="{{collapsed ? 'Maximize sidebar' : 'Minimize sidebar'}}"
                 container="body"
                 placement="right">
@@ -15,12 +15,12 @@
                  customClass="badge-parent"
                  (select)="onTabClick(true)">
                 <template tabHeading>
-                    Review
+                    Check
                     <span *ngIf="errors.total()" class="badge badge-corner"
                           [ngClass]="{'badge-danger': numPending}">{{errors.total()}}</span>
                 </template>
             </tab>
-            <tab heading="Types"
+            <tab heading="Add"
                  [active]="!isStatus"
                  (select)="onTabClick(false)"></tab>
         </tabset>
@@ -37,7 +37,7 @@
                    [tooltip]="item.label"
                    container="body">
                     <i class="fa fa-lg text-center {{item.feature.type.icon}}"></i>
-                    {{!collapsed ? '&nbsp;&nbsp;Add ' + item.feature.typeName : ''}}
+                    {{!collapsed ? '&nbsp;&nbsp;' + item.feature.typeName + ' ' + addUnit(item.feature.size()) : ''}}
                 </a>
                 <div class="row-input"
                    [ngClass]="{'has-error': itemType.invalid && itemType.touched}"
@@ -83,20 +83,31 @@
                 </button>
             </li>
         </form>
-        <li  *ngIf="!isStatus && !editing" class="sidebar-item type-control">
-            <a (click)="onEditModeToggle($event)">
-                <strong class="fa-stack">
-                    <i class="fa fa-circle fa-stack-2x"></i>
-                    <i class="fa fa-pencil fa-stack-1x fa-inverse"></i>
-                </strong>
-                {{!collapsed ? '&nbsp;Edit types' : ''}}
-            </a>
-        </li>
-        <li *ngIf="!isStatus && !editing" class="sidebar-item type-control">
-            <a (click)="onAddClick($event)">
-                <i class="fa fa-fw fa-plus-circle fa-lg"></i>
-                {{!collapsed ? '&nbsp;&nbsp;New type' : ''}}
-            </a>
+        <li *ngIf="!isStatus && !editing" class="text-right">
+            <button *ngIf="!collapsed" class="advanced-btn btn btn-link btn-sm"
+                    (click)="toggleAdvanced()">
+                <i class="fa fa-chevron-circle-right" aria-hidden="true"
+                   [ngClass]="{'fa-rotate-90': isAdvancedOpen}"></i>
+                Advanced
+            </button>
+            <ul class="sidebar-menu advanced-menu text-left"
+                [ngClass]="{'collapsed-box': !isAdvancedOpen}">
+                <li class="sidebar-item type-control">
+                    <a (click)="onEditModeToggle($event)">
+                        <strong class="fa-stack">
+                            <i class="fa fa-circle fa-stack-2x"></i>
+                            <i class="fa fa-pencil fa-stack-1x fa-inverse"></i>
+                        </strong>
+                        {{!collapsed ? '&nbsp;Edit types' : ''}}
+                    </a>
+                </li>
+                <li *ngIf="!isStatus && !editing" class="sidebar-item type-control">
+                    <a (click)="onNewTypeClick($event)">
+                        <i class="fa fa-fw fa-plus-circle fa-lg"></i>
+                        {{!collapsed ? '&nbsp;&nbsp;New type' : ''}}
+                    </a>
+                </li>
+            </ul>
         </li>
 
         <!-- Review tab -->
@@ -105,8 +116,8 @@
                 [ngClass]="{'col-md-12': !collapsed}">
                 <i class="fa fa-check-circle" aria-hidden="true"
                     [ngClass]="{'fa-2x': collapsed, 'fa-4x': !collapsed}"></i>
-                <h4>All fields are valid</h4>
-                <h4>You may submit your study now</h4>
+                <h4 [ngClass]="{'vertical-text': collapsed}">All fields are valid</h4>
+                <h4 class="action-title">You may submit your study now</h4>
             </li>
             <li class="sidebar-item" *ngFor="let control of formControls; let i = index">
                 <a *ngIf="control.invalid"
@@ -129,7 +140,7 @@
     </ul>
 </aside>
 <subm-add-dialog #addDialog
-                [onAddType]="onAdd.bind(this)">
+                [onAddType]="onAddType.bind(this)">
 </subm-add-dialog>
 <confirm-dialog #confirmDialog
                 headerTitle="Delete items"

--- a/src/app/submission/edit/subm-view.component.ts
+++ b/src/app/submission/edit/subm-view.component.ts
@@ -11,13 +11,14 @@ import {
 import {SubmEditComponent} from "./subm-edit.component";
 import {PageTab} from "../shared/pagetab.model";
 import {SubmissionType} from "../shared/submission-type.model";
+import {Observable} from "rxjs/Observable";
 
 @Component({
     selector: 'subm-view',
     templateUrl: './subm-edit.component.html',
 })
 export class SubmViewComponent extends SubmEditComponent {
-    ngOnInit() {
+    ngOnInit(): Observable<any> {
         this.readonly = true;
         this.route.params.forEach((params: Params) => {
             this.accno = params['accno'];
@@ -32,5 +33,7 @@ export class SubmViewComponent extends SubmEditComponent {
                     this.changeSection(this.subm.root.id);
                 });
         });
+
+        return Observable.of(true);
     }
 }

--- a/src/app/submission/list/ag-grid/date-filter.component.ts
+++ b/src/app/submission/list/ag-grid/date-filter.component.ts
@@ -73,13 +73,12 @@ class DateRange {
         </select>
         <date-input
             *ngIf="after || between"
-            [(ngModel)]="date.from"
-            bsstDateFormat>
+            [canUsePastDates]="true"
+            [(ngModel)]="date.from">
         </date-input>
         <date-input
             *ngIf="before || between"
-            [(ngModel)]="date.to"
-            bsstDateFormat>
+            [(ngModel)]="date.to">
         </date-input>
     </div>
     <div style="padding:0 5px 5px 5px;text-align:right">

--- a/src/app/submission/list/subm-list.component.html
+++ b/src/app/submission/list/subm-list.component.html
@@ -4,12 +4,14 @@
 
         <span class="pull-right">
             <button class="btn btn-primary"
-               (click)="uploadSubmission()">
+                    (click)="uploadSubmission()"
+                    [disabled]="isBusy">
                 <i class="fa fa-upload" aria-hidden="true"></i>
                 <span>Direct upload</span>
             </button>
             <button class="btn btn-primary"
-               (click)="createSubmission()">
+                    (click)="createSubmission()"
+                    [disabled]="isBusy">
                 <i class="fa fa-plus-circle" aria-hidden="true"></i>
                 <span>Add new</span>
             </button>
@@ -19,7 +21,7 @@
                  (select)="onSubmTabSelect(false)">
                 <template tabHeading>
                     <i class="fa fa-clock-o" aria-hidden="true"></i>
-                    Temporary
+                    Pending
                 </template>
             </tab>
             <tab [active]="showSubmitted"

--- a/src/app/submission/results/subm-results-modal.component.ts
+++ b/src/app/submission/results/subm-results-modal.component.ts
@@ -17,9 +17,9 @@ import {BsModalRef} from 'ngx-bootstrap/modal/modal-options.class';
     templateUrl: './subm-results-modal.component.html'
 })
 export class SubmResultsModalComponent {
-    @Input() log: any;          //Log part of the server's response
-    @Input() mapping: any[];    //Mapping part of the server's response
-    @Input() status: string;    //Status the server comes back with
+    @Input() status: string;        //Status the server comes back with
+    @Input() accno: string;         //Submission's accession number
+    @Input() log: any;              //Log part of the server's response
 
     constructor(private router: Router,
                 public bsModalRef: BsModalRef) {
@@ -27,19 +27,6 @@ export class SubmResultsModalComponent {
 
     get location() {
         return window.location;
-    }
-
-    /**
-     * Extracts the accession number from the server's response, taking into account whether the
-     * study is new or not. The former will have its accession number added under the mapping section.
-     * @returns {string} Accession number assigned to the submitted study
-     */
-    get accno(): string {
-        if (this.mapping.length && this.mapping[0].hasOwnProperty('assigned') && this.mapping[0].assigned) {
-            return this.mapping[0].assigned;
-        } else {
-            return this.log.subnodes[2].subnodes[0].subnodes[0].message.split(':')[1].trim();
-        }
     }
 
     /**

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -34,7 +34,7 @@ export const DefaultTemplate = {
             {
                 'name': 'Title',
                 'icon': 'fa-font',
-                'valueType': 'text',
+                'valueType': 'textblob',
                 'required': true,
                 'minlength': 50
             },
@@ -81,7 +81,8 @@ export const DefaultTemplate = {
                     },
                     {
                         'name': 'ORCID',
-                        'valueType': 'text'
+                        'valueType': 'orcid',
+                        'displayed': true
                     },
                     {
                         'name': 'Address',

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -170,8 +170,9 @@ export class AnnotationsType extends FeatureType {
 }
 
 export class ColumnType extends BaseType {
-    readonly required: boolean;
-    readonly valueType: ValueType;
+    readonly required: boolean;     //required data-wise: its fields should have data associated with it to be valid
+    readonly displayed: boolean;    //required render-wise: should be visually available regardless of its fields being required or not
+    readonly valueType: ValueType;  //type of data for the fields under this column
 
     static createDefault(name: string, scope?: Map<string, any>): ColumnType {
         return new ColumnType(name, undefined, scope);
@@ -183,6 +184,7 @@ export class ColumnType extends BaseType {
         other = other || {};
         this.valueType = other.valueType || 'text';
         this.required = other.required === true;
+        this.displayed = other.displayed || false;
     }
 }
 
@@ -287,6 +289,11 @@ export class SubmissionType extends BaseType {
 export class TemplateType extends BaseType {
     readonly submissionType: SubmissionType;
 
+    constructor(name: string, obj?: any, scope?: Map<string, any>) {
+        super(name, obj !== undefined, scope);
+        this.submissionType = new SubmissionType('Submission', obj, new Map());
+    }
+
     static create(tmpl: any): TemplateType {
         const tmplName = tmpl.name;
         if (tmplName === undefined) {
@@ -296,11 +303,6 @@ export class TemplateType extends BaseType {
             return GlobalScope.get(tmplName);
         }
         return new TemplateType(tmplName, tmpl, GlobalScope);
-    }
-
-    constructor(name: string, obj?: any, scope?: Map<string, any>) {
-        super(name, obj !== undefined, scope);
-        this.submissionType = new SubmissionType('Submission', obj, new Map());
     }
 }
 

--- a/src/config.json
+++ b/src/config.json
@@ -1,8 +1,11 @@
 {
-  "APP_PROXY_BASE":"/proxy",
-  "APP_CONTEXT":"/",
-  "APP_DEBUG_ENABLED":true,
-  "APP_PROD":true,
-  "APP_VERSION":"2.5",
-  "APP_TABLET_BREAKPOINT": 993
+  "APP_PROXY_BASE": "/proxy",
+  "APP_CONTEXT": "/",
+  "APP_DEBUG_ENABLED": true,
+  "APP_PROD": true,
+  "APP_VERSION": "2.5",
+  "APP_TABLET_BREAKPOINT": 993,
+  "APP_CAN_PAST_DATES": false,
+  "APP_DATE_LIST_FORMAT": "dd MMM yyyy",
+  "APP_DATE_INPUT_FORMAT": "DD MMM YYYY"
 }

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -1,3 +1,5 @@
+/* Styles that modify default Bootstrap behaviour or relies on Bootstrap's variables */
+
 @left-side-width: 200px;
 @left-side-width-collapse: 40px;
 
@@ -198,7 +200,7 @@ aside {
   }
 }
 
-/* Makes unselected tabs be on a plane behind selected ones with a permanent shaded appearance. Also bumps up their weight */
+//Makes unselected tabs be on a plane behind selected ones with a permanent shaded appearance. Also bumps up their weight
 .nav-tabs > .nav-item > .nav-link {
   font-weight: 500;
 }
@@ -209,7 +211,7 @@ aside {
   z-index: 100;
 }
 
-/* Gives readonly inputs and features the appearance of standard text */
+//Gives readonly inputs and features the appearance of standard text
 input[readonly], textarea[readonly] {
   font-size: @font-size-base;
   text-overflow: ellipsis;
@@ -223,7 +225,16 @@ input[readonly], textarea[readonly] {
   padding-left: 0;
 }
 
-/* Convenience classes for top-right-corner badge indicators */
+//Makes labels' size to reflect font-size without compromising spacing between form element
+.control-label {
+  padding-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+.form-group {
+  padding-top: 7px;
+}
+
+//Convenience classes for top-right-corner badge indicators
 .badge-parent {
   position: relative;
 }
@@ -246,7 +257,7 @@ input[readonly], textarea[readonly] {
   transform: rotate(-90deg);
 }
 
-//Brings date picker's styles in line with the app.
+//Brings date picker's styles in line with the app's and removes pointer over inactive/disabled day cells
 .bs-datepicker {
   z-index: 2000;
   border-radius: 4px;
@@ -266,9 +277,12 @@ input[readonly], textarea[readonly] {
 .bs-datepicker-body table td span:not(.disabled):not(.is-other-month) {
   font-weight: 500;
 }
-.bs-datepicker-body table td span.disabled, .bs-datepicker-body table td.disabled span {
+.bs-datepicker-body table td span.disabled,
+.bs-datepicker-body table td span.is-other-month,
+.bs-datepicker-body table td.disabled span {
   cursor: default;
 }
+
 
 //Restores the border radius applied to right corners on fields inside input-groups
 .input-group .subm-field .form-control {

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -111,8 +111,7 @@
   }
 }
 
-/* Prevents cell menu buttons from being hidden. By default, only shown on hover.
-   Also, brings it in line with app's styles. */
+/* Prevents cell menu buttons from being hidden. By default, only shown on hover. */
 .ag-header-cell-menu-button {
   float: left;
   opacity: 1 !important;
@@ -122,6 +121,11 @@
 }
 .ag-fresh .ag-header-cell-menu-button:hover  {
   border-color: #fafafa;
+}
+
+/* Permanently hides filter icon */
+.ag-filter-icon {
+  display: none !important;
 }
 
 /* Center-aligns ag-grid cells marked accordingly */
@@ -198,4 +202,18 @@ component */
 }
 .has-error .validation-pop {
   visibility: visible;
+}
+
+//Forces muted italics to have a slightly lighter shade
+.text-muted i:not(.fa) {
+  color: #a2a2a2;
+}
+
+//Shades an entire area, preventing any interaction as well.
+//TODO: Optimistic approach (IE11+). Depending on user response, this could need replacing with the traditional method.
+.disabled {
+  -webkit-filter: grayscale(100%);
+  -ms-filter: grayscale(100%);
+  filter: grayscale(100%);
+  pointer-events: none;
 }

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -211,9 +211,9 @@ component */
 
 //Shades an entire area, preventing any interaction as well.
 //TODO: Optimistic approach (IE11+). Depending on user response, this could need replacing with the traditional method.
-.disabled {
+.grayout {
   -webkit-filter: grayscale(100%);
-  -ms-filter: grayscale(100%);
+  ms-filter: gray;
   filter: grayscale(100%);
   pointer-events: none;
 }


### PR DESCRIPTION
- Implements autofill of user credentials within the contacts grid for new submissions (#79).

- Prepares the ground for the unification of all fields in the app using the subm-field class, starting with the ORCID fields in the signup form and submission's edit contact grid.

- Generalises the UserData class to make it independent of object nesting levels and request timing.

- Exposes date formats and a switch for past dates in the app-wide configuration file, with the option of overriding global configuration through input binding in the date picker component.

- Adds read-only mode to file selector and fixes validation of unknown file paths in case the "u/" path bug ever surfaces again. If the path is unknown, the field is wiped clean and considered blank for validation purposes, preventing the user to submit the form.

- Adds detection of submission's type and revision status.

- Refactors accession number retrieval in the submission results modal.

- Restores text length requirement cues for top-level fields.

- Adds re-submission state to submission form and streamlines interaction model with sent submissions, hiding revisions from the temporary submission list.

- Implements detection of revised submissions and adds a revert button inside the edit submission modal.

- Fixes delete issue with sent submission that have a revision (only the revision is deleted).

- Takes into account camel-casing of property names in server responses.

- Allows the programmatic change of field values once the form has been rendered while also normalising attribute names to lower case internally.

- Adds the “displayed” condition to the default template to cater for attributes within a grid that need to be rendered but are not required. The ORCID column, for example.

- Separates the required stated from the disabled one for the inline-edit column fields.

- Encloses edit and new type options within an accordion-like panel to enable simplification of vocabulary on sidebar tabs.

- Refactors update detection in submission edit view to allow the expression of watched non-bubbling events as an array. Also fixes change detection in annotations.

- Fixes various other UX and styling issues, especially for the direct submit and add new type forms.