### PR TITLE
Pubmed ID search box

### DIFF
--- a/src/app/shared/inline-edit.component.html
+++ b/src/app/shared/inline-edit.component.html
@@ -1,6 +1,6 @@
 <div class="inline-edit-wrapper"
      [ngClass]="{'editable': canEdit, 'text-muted': !editing}">
-    <input class="form-control form-control-auto" type="text" tabindex="-1"
+    <input class="form-control form-control-auto" type="text" tabindex="-1" autocomplete="off"
            [required]="required"
            [(ngModel)]="value"
            [placeholder]="placeholder"

--- a/src/app/shared/orcid-input-box.component.html
+++ b/src/app/shared/orcid-input-box.component.html
@@ -1,4 +1,13 @@
 <div [ngClass]="{'input-group': isPopupButton}">
+    <input type="text"
+           class="form-control"
+           [ngClass]="{'input-sm': isSmall}"
+           [(ngModel)]="value"
+           (blur)="onBlur()"
+           pattern="\d{4}-\d{4}-\d{4}-\d{4}"
+           placeholder="{{!readonly ? 'e.g. 1892-5647-2571-9436' : ''}}"
+           [readonly]="readonly"
+           #inputModel="ngModel">
     <span *ngIf="isPopupButton" class="input-group-btn">
         <button class="btn btn-sm btn-primary" type="button"
                 [ngClass]="{'btn-sm': isSmall}"
@@ -6,12 +15,4 @@
             <i class="fa fa-external-link" aria-hidden="true"></i>
         </button>
     </span>
-    <input type="text"
-           class="form-control"
-           [ngClass]="{'input-sm': isSmall}"
-           [(ngModel)]="value"
-           (blur)="onBlur()"
-           pattern="\d{4}-\d{4}-\d{4}-\d{4}"
-           placeholder="e.g. 1892-5647-2571-9436"
-           #inputModel="ngModel">
 </div>

--- a/src/app/shared/orcid-input-box.component.ts
+++ b/src/app/shared/orcid-input-box.component.ts
@@ -32,9 +32,11 @@ import 'rxjs/add/observable/timer';
 export class ORCIDInputBoxComponent implements ControlValueAccessor {
     private onChange: any = (_:any) => {};      //placeholder for handler propagating changes outside the custom control
     private onTouched: any = () => {};          //placeholder for handler after the control has been "touched"
+
     private orcidValue = '';                    //internal data model
     private mlistener = null;
 
+    @Input() readonly?: boolean = false;
     @Input() isPopupButton: boolean = true;     //flag for showing/hiding popup button
     @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
 

--- a/src/app/submission-shared/date-input.component.ts
+++ b/src/app/submission-shared/date-input.component.ts
@@ -31,6 +31,8 @@ import {AppConfig} from "../app.config";
 /**
  * Custom component for the Bootstrap's datepicker. It allows for a default value and makes sure the resulting
  * component behaves exactly like a read-only input field (so that input is only allowed through the date picker).
+ * It allows the display format for the date to be different to the transactional one if needed (the latter is
+ * hard-coded to ISO 8601 YYYY-MM-DD).
  * NOTE: Contrary to what its name suggests, DatePicker's "bsValueChange" output event is triggered every time
  * a date is set, NOT on change exclusively.
  * @see {@link https://valor-software.com/ngx-bootstrap/old/1.9.3/#/datepicker}
@@ -57,10 +59,6 @@ export class DateInputComponent implements ControlValueAccessor {
     constructor(config: BsDatepickerConfig, private appConfig: AppConfig, private rootEl: ElementRef) {
         config.showWeekNumbers = false;
         config.dateInputFormat = appConfig.dateInputFormat;
-
-        /*if (!appConfig.canUsePastDates) {
-            config.minDate = new Date(Date.now());
-        }*/
     }
 
     /**
@@ -130,7 +128,10 @@ export class DateInputComponent implements ControlValueAccessor {
         }
     }
 
-    //and disabling past dates if applicable.
+    /**
+     * Disables past dates if so defined in the corresponding input binding. If there is none, it falls back
+     * on the app-wide config's relevant entry.
+     */
     ngOnInit(): void {
         if ((typeof this.canUsePastDates === 'undefined' && !this.appConfig.canUsePastDates) ||
             (this.canUsePastDates === false)) {

--- a/src/app/submission-shared/pubmedid-search/pubmedid-search.component.css
+++ b/src/app/submission-shared/pubmedid-search/pubmedid-search.component.css
@@ -1,0 +1,44 @@
+/* Repurposes Bootstrap's drop-down implementation as a single-suggestion type-ahead list.
+   NOTE: As is, NGX's type-ahead is not stable enough for async data and it's really designed for
+   multiple suggestions at a time, not for a single search result */
+.form-control, .input-group-btn {
+    display: inline;
+}
+.form-control {
+    padding-right: 3rem;
+}
+.input-group-btn {
+    position: static;
+}
+.btn-link {
+    position: absolute;
+    right: 0.5vw;
+}
+
+/* Aligns the menu with the left edge of the input field  and guarantees two lines of space.
+   Shows an ellipsis only when more than two lines of content exist.
+   NOTE: multi-line ellipsis is not widely supported. Fallback is text truncation. */
+.dropdown-menu {
+    left: 0.5vw;
+    z-index: 900;           /* below any nav bar or popovers */
+    max-height: 50px;
+    max-width: 800px;
+    width: 290%;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+}
+.dropdown-menu > li > a {
+    padding: 2px 10px;
+    white-space: normal;
+}
+.open > .dropdown-menu {
+    display: block;
+    display: -webkit-box;
+}
+@media only screen and (min-width: 845px) {
+    .dropdown-menu {
+        width: 400%;
+    }
+}

--- a/src/app/submission-shared/pubmedid-search/pubmedid-search.component.html
+++ b/src/app/submission-shared/pubmedid-search/pubmedid-search.component.html
@@ -1,0 +1,27 @@
+<input class="form-control input-sm" type="text"
+       placeholder="{{!readonly ? 'Find by PubMed ID' : ''}}"
+       [(ngModel)]="value"
+       (ngModelChange)="search()"
+       (keyup.enter)="searchOnKeypress($event)"
+       [readonly]="readonly"
+       [required]="required">
+<span *ngIf="!readonly" class="input-group-btn dropup"
+      [ngClass]="{'open': isPreviewPub}">
+    <button class="btn btn-link btn-sm dropdown-toggle" type="button"
+            [disabled]="isBusy || !pubMedId"
+            (click)="togglePreviewPub()">
+        <i class="fa fa-fw fa-lg" aria-hidden="true"
+           [ngClass]="{ 'fa-cog fa-spin': isBusy, 'fa-search': !isBusy}"></i>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li role="menuitem">
+            <a class="dropdown-item" href="javascript:void(0)"
+               (click)="selectPub()">
+                {{publication.authors?.split(',').slice(0, 2).join(',')}} <!-- Shows just the two first authors -->
+                <strong>{{publication.title}}</strong>
+                {{publication.year}}{{publication.volume? ';' : '.'}}
+                {{publication.volume}}{{publication.issue ? '(' + publication.issue + ').' : ''}}
+            </a>
+        </li>
+    </ul>
+</span>

--- a/src/app/submission-shared/pubmedid-search/pubmedid-search.component.ts
+++ b/src/app/submission-shared/pubmedid-search/pubmedid-search.component.ts
@@ -22,7 +22,7 @@ import {PubMedSearchService} from './pubmedid-search.service';
     selector: 'pubmedid-search',
     template: `
     <input type="text" class="form-control input-sm"
-           placeholder="Enter Pub Med Id" 
+           placeholder="e.g. 24265224" 
            [(ngModel)]="value"
            (ngModelChange)="ngOnChanges()"
            [readonly]="readonly">
@@ -55,27 +55,15 @@ export class PubMedIdSearchComponent implements ControlValueAccessor, OnChanges 
             .subscribe((resp) => {
                 console.log("pubMedId search:", resp);
                 if (resp.hasOwnProperty('title')) {
-                    this.found.emit(this.uppercaseProperties(resp));
+                    this.found.emit(resp);
                 }
             });
     }
 
-    uppercaseProperties(obj) {
-        let res = {};
-        for (let key in obj) {
-            if (obj.hasOwnProperty(key)) {
-                res[key.charAt(0).toUpperCase() + key.substring(1)] = obj[key];
-            }
-        }
-        console.log("upperCaseProperties:", res);
-        return res;
-    }
-
     private changed = new Array<(value: string) => void>();
     private touched = new Array<() => void>();
-    private validateFn: any = () => {
-    };
 
+    private validateFn: any = () => {};
 
     get value() {
         return this.pubMedId;

--- a/src/app/submission-shared/pubmedid-search/pubmedid-search.component.ts
+++ b/src/app/submission-shared/pubmedid-search/pubmedid-search.component.ts
@@ -2,98 +2,163 @@ import {
     Component,
     Input,
     Output,
-    OnChanges,
     forwardRef,
     EventEmitter
 } from '@angular/core';
 
 import {
-    FormControl,
     ControlValueAccessor,
-    NG_VALUE_ACCESSOR,
-    NG_VALIDATORS
+    NG_VALUE_ACCESSOR
 } from '@angular/forms';
 
 import * as _ from 'lodash';
 
 import {PubMedSearchService} from './pubmedid-search.service';
+import {Observable} from "rxjs/Observable";
 
 @Component({
     selector: 'pubmedid-search',
-    template: `
-    <input type="text" class="form-control input-sm"
-           placeholder="e.g. 24265224" 
-           [(ngModel)]="value"
-           (ngModelChange)="ngOnChanges()"
-           [readonly]="readonly">
-`, providers: [
-        {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => PubMedIdSearchComponent), multi: true},
-        {provide: NG_VALIDATORS, useExisting: forwardRef(() => PubMedIdSearchComponent), multi: true}
-    ]
+    templateUrl: './pubmedid-search.component.html',
+    styleUrls: ['./pubmedid-search.component.css'],
+    providers: [{
+        provide: NG_VALUE_ACCESSOR,
+        useExisting: forwardRef(() => PubMedIdSearchComponent),
+        multi: true
+    }]
 })
-export class PubMedIdSearchComponent implements ControlValueAccessor, OnChanges {
-    @Input() readonly?: boolean = false;
 
+/**
+ * PubMed ID lookup field implemented in the vein of an auto-suggest search box where the suggestion
+ * acts as a preview of the with confirmation from the user by selection. It fetches publication data on
+ * de-bounced key presses, supports the enter key and allows for any previously fetched publication data
+ * to be displayed again (1st enter key press) or actioned upon (2nd key press).
+ */
+export class PubMedIdSearchComponent implements ControlValueAccessor {
+    private onChange: any = (_:any) => {};      //placeholder for handler propagating changes outside the custom control
+    private onTouched: any = () => {};          //placeholder for handler after the control has been "touched"
+
+    private isBusy: boolean = false;            //indicates a transaction is in progress
+    private isPreviewPub: boolean = false;      //indicates if the retrieved publication's summary preview is on display
+    private pubMedId: string;                   //last PubMed ID number typed in
+    private lastIDfetched: string;              //helps cancel unnecessary search actions triggered by enter key
+    private publication: object = {};           //last publication retrieved
+
+    @Input() required?: boolean = false;
+    @Input() readonly?: boolean = false;
     @Output() found: EventEmitter<any> = new EventEmitter<any>();
 
-    private pubMedId: string;
-
-    private debouncedSearch = _.debounce(this.pubMedSearch, 1000);
-
     constructor(private pubMedSearchService: PubMedSearchService) {
+        this.pubMedFetch = _.debounce(this.pubMedFetch, 300);
     }
-
-    ngOnChanges() {
-        if (this.pubMedId) {
-            this.debouncedSearch();
-        }
-    }
-
-    pubMedSearch() {
-        this.pubMedSearchService
-            .search(this.pubMedId)
-            .subscribe((resp) => {
-                console.log("pubMedId search:", resp);
-                if (resp.hasOwnProperty('title')) {
-                    this.found.emit(resp);
-                }
-            });
-    }
-
-    private changed = new Array<(value: string) => void>();
-    private touched = new Array<() => void>();
-
-    private validateFn: any = () => {};
 
     get value() {
         return this.pubMedId;
     }
 
-    set value(val) {
-        if (this.pubMedId !== val) {
-            this.pubMedId = val;
-            this.changed.forEach(f => f(val));
+    set value(newValue) {
+        if (this.pubMedId !== newValue) {
+            this.pubMedId = newValue;
+            this.onChange(newValue);
         }
     }
 
-    //From ControlValueAccessor interface
-    writeValue(value: any) {
-        if (value) {
-            this.pubMedId = value;
+    /**
+     * Writes a new value from the form model into the view or (if needed) DOM property.
+     * @see {@link ControlValueAccessor}
+     * @param newValue - Value to be stored.
+     */
+    writeValue(newValue: any) {
+        if (newValue) {
+            this.pubMedId = newValue;
         }
     }
 
-    //From ControlValueAccessor interface
-    registerOnChange(fn: (value: string) => void) {
-        this.changed.push(fn);
+    /**
+     * Registers a handler that should be called when something in the view has changed.
+     * @see {@link ControlValueAccessor}
+     * @param fn - Handler telling other form directives and form controls to update their values.
+     */
+    registerOnChange(fn) {
+        this.onChange = fn;
     }
 
-    //From ControlValueAccessor interface
-    registerOnTouched(fn: () => void) {
-        this.touched.push(fn);
+
+    /**
+     * Registers a handler specifically for when a control receives a touch event.
+     * @see {@link ControlValueAccessor}
+     * @param fn - Handler for touch events.
+     */
+    registerOnTouched(fn: any) {
+        this.onTouched = fn;
     }
 
-    validate(c: FormControl) {
-        return this.validateFn(c);
+    /**
+     * Performs a new lookup operation provided the field is not blank and there is no request in progress.
+     * It also hides the previous search result's preview if on display.
+     */
+    search() {
+        if (this.pubMedId && !this.isBusy) {
+            this.isPreviewPub = false;
+            this.pubMedFetch();
+        }
+    }
+
+    /**
+     * Performs a lookup operation on pressing a certain key (filtered at the template level) as long as the
+     * ID being searched is different from the last one. Otherwise it just directly selects the previously
+     * searched publication for autofill.
+     * @param {Event} event - DOM event for the click action.
+     */
+    searchOnKeypress(event: Event) {
+        event.stopPropagation();
+
+        if (this.pubMedId != this.lastIDfetched) {
+            this.search();
+        } else if (this.pubMedId) {
+            this.selectPub();
+        }
+    }
+
+    /**
+     * Retrieves the publication data for the ID present in the search field shows its preview, ready
+     * for selection so the user wishes. It will also notify the template that the transaction is going on so that
+     * no further action is allowed in the interim.
+     * @returns {Observable<any>} Stream of HTTP client events.
+     */
+    pubMedFetch(): Observable<any> {
+        let eventStream;
+
+        this.isBusy = true;
+        eventStream = this.pubMedSearchService.search(this.pubMedId);
+        eventStream.subscribe((response) => {
+            this.isBusy = false;
+            this.lastIDfetched = this.pubMedId;
+            if (response.hasOwnProperty('title')) {
+                this.publication = response;
+                this.isPreviewPub = true;
+            }
+        });
+
+        return eventStream;
+    }
+
+    /**
+     * Bubbles the selected publication event up, hiding its preview too.
+     */
+    selectPub() {
+        this.found.emit(this.publication);
+        this.isPreviewPub = false;
+    }
+
+    /**
+     * Shows or hides the publication's preview. If there is no preview to be shown because the field
+     * has just been rendered, it checks for an already existing ID and retrieves the publication for that one.
+     */
+    togglePreviewPub() {
+        if (this.pubMedId && _.isEmpty(this.publication) && !this.isPreviewPub ) {
+            this.pubMedFetch();
+            return;
+        }
+        this.isPreviewPub = !this.isPreviewPub;
     }
 }

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -266,6 +266,7 @@ export class SubmEditComponent implements OnInit, OnDestroy {
             return;
         }
 
+        //TODO: this could probably do with its own method
         this.submService.submitSubmission(this.wrap())
             .subscribe(
                 resp => {

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -38,8 +38,8 @@ import {SubmFormComponent} from "./subm-form/subm-form.component";
 import {AppConfig} from "../../app.config";
 import {FieldControl} from "./subm-form/subm-form.service";
 import {UserData} from "../../auth/user-data";
-import {SubmSideBarComponent} from "./subm-sidebar/subm-sidebar.component";
 import {SubmValidationErrorsComponent} from "./subm-navbar/subm-validation-errors.component";
+import * as _ from "lodash";
 
 @Component({
     selector: 'subm-edit',
@@ -81,6 +81,11 @@ export class SubmEditComponent implements OnInit, OnDestroy {
 
         //Initally collapses the sidebar for tablet-sized screens if applicable
         this.sideBarCollapsed = window.innerWidth < this.appConfig.tabletBreak;
+
+        //Avoids unnecessary post requests in case there's a cascade of updates from programmatic changes
+        //NOTE: All calls are coalesced into the last one since it's that one that will lead to the most
+        //up-to-date copy of the submission.
+        this.onChange = _.throttle(this.onChange, 500, {'leading': false});
     }
 
     //TODO: this need splitting up. Especially the part dealing with server transactions and transformation of data.
@@ -164,6 +169,7 @@ export class SubmEditComponent implements OnInit, OnDestroy {
     ngAfterViewChecked() {
         if (this.submForm) {
             this.submForm.sectionForm.controls(this.formControls);
+            this.changeRef.detectChanges();
         }
     }
 

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -47,6 +47,7 @@
                             [readonly]="readonly"
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
+                            (async)="addOnAsync($event, rowIdx)"
                             isSmall="true"
                             validate-onblur>
                 </subm-field>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -4,12 +4,11 @@ import {
     ElementRef,
     Input,
     QueryList,
-    ViewChildren
+    ViewChildren,
 } from '@angular/core';
 
 import {Feature, Attribute, ValueMap} from '../../../shared/submission.model';
 import {FeatureForm} from '../subm-form.service';
-import {AbstractControl} from "@angular/forms";
 
 @Component({
     selector: 'subm-feature-grid',
@@ -21,6 +20,8 @@ export class FeatureGridComponent implements AfterViewInit {
     @Input() readonly? = false;
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
     @ViewChildren('colEl') colEls: QueryList<ElementRef>;
+
+    constructor(private rootEl: ElementRef) {}
 
     get rows(): ValueMap[] {
         return this.featureForm.rows;
@@ -38,7 +39,7 @@ export class FeatureGridComponent implements AfterViewInit {
         let oldNumRows = this.featureForm.rows.length;      //initial row count
         let oldNumCols = this.featureForm.columns.length;   //initial column count
 
-        //On DOM change, updates row and column count and compares it to the respective old value to find out if
+        //On DOM change, compares current row and column count with the respective old value to find out if
         //a row or column was added.
         this.rowEls.changes.subscribe((rowEls) => {
 
@@ -54,5 +55,36 @@ export class FeatureGridComponent implements AfterViewInit {
             oldNumRows = this.featureForm.rows.length;
             oldNumCols = this.featureForm.columns.length;
         });
+    }
+
+    /**
+     * Changes the values of an existing feature's row fields to those of a given a set of grid attributes,
+     * bubbling a single DOM change event for all of them.
+     * @param {object} data - Grid attribute data retrieved asynchronously.
+     * @param {number} rowIdx - Row whose field values are to be changed.
+     */
+    addOnAsync(data: any, rowIdx: number) {
+        const columns = this.feature.columns.slice(0);
+        const attrNames = Object.keys(data);
+        const attributes = [];
+
+        //The first column is assumed to be the source of the async event and, therefore, does not require updating.
+        columns.shift();
+
+        //Converts data into attributes by filling in gaps (existing columns not included in the attributes).
+        //This also guarantees that no new columns will be added.
+        columns.forEach((column) => {
+            const colName = column.name.toLowerCase();
+
+            if (attrNames.indexOf(colName) == -1) {
+                attributes.push({name: colName, value: ''});
+            } else {
+                attributes.push({name: colName, value: data[colName]});
+            }
+        });
+
+        //Updates the row and notifies the a single change.
+        this.feature.add(attributes, rowIdx);
+        this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
     }
 }

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -25,9 +25,10 @@ export class SubmFeatureComponent implements OnInit {
 
     constructor(private changeRef: ChangeDetectorRef) {}
 
+    /**
+     * Defines the actions of the feature's menu according to its type (list or not).
+     */
     ngOnInit() {
-
-        //Defines the actions of the feature's menu according to its type (list or not).
         this.actions.push({
             label: 'Add column',
             invoke: () => this.feature.addColumn()
@@ -44,7 +45,9 @@ export class SubmFeatureComponent implements OnInit {
         return this.featureForm === undefined ? undefined : this.featureForm.feature;
     }
 
-    //Counts the number of errors if the feature is not empty.
+    /**
+     * Counts the number of errors if the feature is not empty.
+     */
     ngDoCheck(): void {
         if (this.featureEl) {
             this.errorNum = this.featureEl.nativeElement.getElementsByClassName('has-error').length;

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -1,5 +1,8 @@
 <input *ngIf="type === 'text'"
        type="text" class="form-control"
+       tooltip="{{isOverflow ? value : ''}}"
+       container="body"
+       placement="bottom"
        [ngClass]="{'input-sm': isSmall}"
        [(ngModel)]="value"
        [readonly]="readonly"
@@ -35,6 +38,12 @@
             [readonly]="readonly"
             (focusout)="onBlur()">
 </file-input>
+
+<pubmedid-search
+        *ngIf="type === 'pubmedid'"
+        [(ngModel)]="value"
+        (found)="asyncData($event)">
+</pubmedid-search>
 
 <textarea *ngIf="type === 'textblob'"
           class="form-control"

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -28,6 +28,7 @@
         *ngIf="type === 'orcid'"
         [isSmall]="isSmall"
         [required]="required"
+        [readonly]="readonly"
         [isPopupButton]="false"
         [(ngModel)]="value">
 </orcid-input-box>
@@ -42,6 +43,8 @@
 <pubmedid-search
         *ngIf="type === 'pubmedid'"
         [(ngModel)]="value"
+        [readonly]="readonly"
+        [required]="required"
         (found)="asyncData($event)">
 </pubmedid-search>
 

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -2,7 +2,7 @@ import {
     Component,
     Input,
     forwardRef,
-    ElementRef, ViewChild
+    ElementRef, ViewChild, Output, EventEmitter
 } from '@angular/core';
 
 import {
@@ -27,6 +27,7 @@ export class SubmFieldComponent implements ControlValueAccessor {
     private onTouched: any = () => {};          //placeholder for handler after the control has been "touched"
 
     private _value = '';
+    private isOverflow: boolean = false;        //indicates if the text content is longer than the field itself.
 
     @Input() name: string;
     @Input() type: string;
@@ -34,6 +35,8 @@ export class SubmFieldComponent implements ControlValueAccessor {
     @Input() required: boolean;
     @Input() formControl: FieldControl;
     @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
+
+    @Output() async: EventEmitter<any> = new EventEmitter<any>();  //signals availability of asynchronous attributes
 
     constructor(private elementRef: ElementRef) { }
 
@@ -52,7 +55,7 @@ export class SubmFieldComponent implements ControlValueAccessor {
      * @param value - Value to be stored
      */
     writeValue(value: any): void {
-        if (value) {
+        if (typeof value !== 'undefined') {
             this.value = value;
         }
     }
@@ -88,5 +91,26 @@ export class SubmFieldComponent implements ControlValueAccessor {
      */
     ngAfterViewInit(): void {
         this.formControl.nativeElement = this.elementRef.nativeElement.querySelector('.form-control');
+    }
+
+    /**
+     * Determines if the field's contents are longer than the actual field's dimensions by probing the DOM directly.
+     */
+    ngAfterViewChecked(): void {
+        const controlEl = this.formControl.nativeElement;
+
+        if (controlEl) {
+            this.isOverflow = controlEl.scrollWidth > controlEl.clientWidth;
+        } else {
+            this.isOverflow = false;
+        }
+    }
+
+    /**
+     * Bubbles up an event for any inbound event in turn triggered by data fetched asynchronously.
+     * @param data - Data retrieved asynchronously.
+     */
+    asyncData(data: any): void {
+        this.async.emit(data);
     }
 }

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -122,7 +122,7 @@
             </li>
             <li class="sidebar-item" *ngFor="let control of formControls; let i = index">
                 <a *ngIf="control.invalid"
-                   tooltip="{{collapsed ? '&quot;' + control.template.name + '&quot; field is ' + tipText(control.errors) : 'Scroll field into view'}}"
+                   tooltip="{{collapsed ? '&quot;' + control.template.name + '&quot; field is ' + tipText(control.errors) : 'Highlight field on the form'}}"
                    container="body"
                    placement="{{collapsed ? 'right' : 'top'}}"
                    (click)="onReviewClick($event, control)">

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -101,9 +101,14 @@ export const DefaultTemplate = {
             {
                 'name': 'Publication',
                 'title': 'Add Publications',
-                'description': 'Search by PubMed identifier, or add information manually if not in PubMed',
+                'description': 'Add relevant publications by PubMed ID number or manually',
                 'icon': 'fa-book',
                 'columnTypes': [
+                    {
+                        'name': 'PubMedID',
+                        'valueType': 'pubmedid',
+                        'displayed': true
+                    },
                     {
                         'name': 'DOI',
                         'valueType': 'text'
@@ -115,27 +120,33 @@ export const DefaultTemplate = {
                     },
                     {
                         'name': 'Authors',
-                        'valueType': 'text'
-                    },
-                    {
-                        'name': 'Type',
-                        'valueType': 'text'
-                    },
-                    {
-                        'name': 'Issue',
-                        'valueType': 'text'
-                    },
-                    {
-                        'name': 'Issn',
-                        'valueType': 'text'
+                        'valueType': 'text',
+                        'displayed': true
                     },
                     {
                         'name': 'Year',
-                        'valueType': 'text'
+                        'valueType': 'text',
+                        'displayed': true
+                    },
+                    {
+                        'name': 'Type',
+                        'valueType': 'text',
+                        'displayed': true
+                    },
+                    {
+                        'name': 'Issue',
+                        'valueType': 'text',
+                        'displayed': true
+                    },
+                    {
+                        'name': 'Issn',
+                        'valueType': 'text',
+                        'displayed': true
                     },
                     {
                         'name': 'Volume',
-                        'valueType': 'text'
+                        'valueType': 'text',
+                        'displayed': true
                     }
                 ]
             },

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -101,22 +101,13 @@ export const DefaultTemplate = {
             {
                 'name': 'Publication',
                 'title': 'Add Publications',
-                'description': 'Add relevant publications by PubMed ID number or manually',
+                'description': 'Add the details of publications that are relevant or complementary to the study',
                 'icon': 'fa-book',
                 'columnTypes': [
                     {
-                        'name': 'PubMedID',
+                        'name': 'PMID',
                         'valueType': 'pubmedid',
                         'displayed': true
-                    },
-                    {
-                        'name': 'DOI',
-                        'valueType': 'text'
-                    },
-                    {
-                        'name': 'Title',
-                        'valueType': 'text',
-                        'required': true
                     },
                     {
                         'name': 'Authors',
@@ -124,12 +115,17 @@ export const DefaultTemplate = {
                         'displayed': true
                     },
                     {
+                        'name': 'Title',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
                         'name': 'Year',
                         'valueType': 'text',
                         'displayed': true
                     },
                     {
-                        'name': 'Type',
+                        'name': 'Volume',
                         'valueType': 'text',
                         'displayed': true
                     },
@@ -139,15 +135,17 @@ export const DefaultTemplate = {
                         'displayed': true
                     },
                     {
-                        'name': 'Issn',
-                        'valueType': 'text',
-                        'displayed': true
+                        'name': 'Type',
+                        'valueType': 'text'
                     },
                     {
-                        'name': 'Volume',
-                        'valueType': 'text',
-                        'displayed': true
-                    }
+                        'name': 'Issn',
+                        'valueType': 'text'
+                    },
+                    {
+                        'name': 'DOI',
+                        'valueType': 'text'
+                    },
                 ]
             },
             {

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -16,13 +16,13 @@ class BaseType {
                 tmplBased: boolean,
                 scope: Map<string, any> = GlobalScope) {
         if (!defined(name)) {
-            console.log(`Error: Type name is undefined ${name}`);
+            console.warn(`Error: Type name is undefined ${name}`);
             return;
         }
 
         //TODO: scope check is not working. Why?
         if (scope.has(name)) {
-            console.log(`Error: Type with name ${name} already exists in the scope`);
+            console.warn(`Error: Type with name ${name} already exists in the scope`);
             return;
         }
         scope.set(name, this);

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -16,10 +16,14 @@ class BaseType {
                 tmplBased: boolean,
                 scope: Map<string, any> = GlobalScope) {
         if (!defined(name)) {
-            throw Error(`Type name is undefined ${name}`);
+            console.log(`Error: Type name is undefined ${name}`);
+            return;
         }
+
+        //TODO: scope check is not working. Why?
         if (scope.has(name)) {
-            throw Error(`Type with name ${name} already exists in the scope`);
+            console.log(`Error: Type with name ${name} already exists in the scope`);
+            return;
         }
         scope.set(name, this);
         this.typeName = name;

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -366,11 +366,11 @@ export class Feature extends HasUpdates<UpdateEvent> {
         const colNames = this._columns.names().map(name => name.toLowerCase());
         let rowMap;
 
-        //Adds a column if any of the passed-in attribute names doesn't exist.
+        //Adds a column if any of the passed-in attribute names doesn't exist, capitalizing it just for display purposes.
         attrNames
             .filter(attrName => colNames.indexOf(attrName.toLowerCase()) < 0)
             .forEach((name) => {
-                    this.addColumn(name);
+                    this.addColumn(_.capitalize(name));
             });
 
         //If row not provided, add it if applicable.

--- a/src/styles/custom-variables.less
+++ b/src/styles/custom-variables.less
@@ -201,7 +201,7 @@
 @input-border-radius-small:      @border-radius-small;
 
 //** Border color for inputs on focus
-@input-border-focus:             #66afe9;
+@input-border-focus:             #4fb7d1;
 
 //** Placeholder text color
 @input-color-placeholder:        #999;

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -197,6 +197,7 @@ component */
 //Makes validation popovers show up only when there is indeed an error.
 .validation-pop {
   visibility: hidden;
+  z-index: 950;           //above any dropdowns but below any nav bar
   min-width: 300px;
   text-align: center;
 }


### PR DESCRIPTION
PubMed ID lookup field implemented in the vein of an auto-suggest search box where the suggestion acts as a preview of the with confirmation from the user by selection. It fetches publication data on de-bounced key presses, supports the enter key and allows for any previously fetched publication data to be displayed again (1st enter key press) or actioned upon (2nd key press).
The submission field component is updated to support an "async" event for data fetched asynchronously. The event is used in features to automatically set all inputs belonging to a given row (the one where the search box is present).