### PR TITLE
Locked mode for grids only

### DIFF
--- a/src/app/auth/user-data.ts
+++ b/src/app/auth/user-data.ts
@@ -63,10 +63,18 @@ export class UserData {
     }
 
     /**
-     * Convenience method to determine the user's role (hard-coded for the moment).
-     * @returns {UserRole} - Public.
+     * Convenience method to determine if the user's role.
+     * @returns {UserRole} Public (hard-coded for the moment).
      */
     get role(): UserRole {
         return UserRole.Public;
+    }
+
+    /**
+     * Convenience method to determine if the user has any priviledges.
+     * @returns {boolean} True if the user enjoys any privileges.
+     */
+    get isPrivileged() : boolean {
+        return this.role != UserRole.Public;
     }
 }

--- a/src/app/auth/user-role.ts
+++ b/src/app/auth/user-role.ts
@@ -1,5 +1,5 @@
 export enum UserRole {
-    Public,
-    User,
-    Admin
+    Public,         //No privileges at all
+    User,           //Some privileges
+    Admin           //Has complete control
 }

--- a/src/app/submission/direct-submit/direct-submit.component.html
+++ b/src/app/submission/direct-submit/direct-submit.component.html
@@ -16,7 +16,7 @@
                [ngClass]="{'collapse-left': collapseSideBar}">
             <div class="help-msg panel">
                 <div *ngIf="!request" class="panel-body">
-                    <h4>New direct upload</h4>
+                    <h4>New direct submission</h4>
                     <p>Please fill in the form on the left. A data file must be provided and may be attached
                         to one or multiple projects. If updating an existing study, the filename must match the study's
                         accession number.</p>

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -97,7 +97,7 @@ export class SubmEditComponent implements OnInit, OnDestroy {
             //Determines if the current submission has just been created
             this.isNew = this.route.snapshot.data.isNew || false;
 
-            //Waits for the fetching of both the user data and the submission data to proceed
+            //Waits for the parallel fetching of both the user data and the submission data to proceed
             eventStream = forkJoin([
                 this.submService.getSubmission(params.accno),
                 this.userData.whenFetched

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -1,13 +1,15 @@
 <div class="container-fluid container-scroll" [formGroup]="featureForm.form">
     <div class="row">
         <div class="cell canton col-xs-1 col-md-1 text-center">
-            <button class="btn-add btn btn-link btn-md" type="button" tabindex="-1"
+            <button *ngIf="userData.isPrivileged" class="btn-add btn btn-link btn-md" type="button" tabindex="-1"
                     [ngClass]="{'invisible': readonly}"
                     [tooltip]="'Add a new ' + feature.typeName.toLowerCase() + ' attribute'"
                     container="body"
                     (click)="feature.addColumn()">
                 <i class="fa fa-plus-circle" aria-hidden="true"></i> Column
             </button>
+            {{userData.isPrivileged ? '' : '&nbsp;'}}
+
         </div><!--
         --><div class="cell heading-cell column-heading col-xs-3 col-md-2" *ngFor="let column of columns; let idx = index">
             <inline-edit
@@ -16,7 +18,7 @@
                     (remove)="feature.removeColumn(column.id)"
                     [formControl]="featureForm.columnControl(column.id)"
                     [required]="column.required"
-                    [disableEdit]="featureForm.columnType(column.id).displayed || readonly">
+                    [disableEdit]="featureForm.columnType(column.id).displayed || readonly || !userData.isPrivileged">
             </inline-edit>
         </div>
     </div>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -9,6 +9,7 @@ import {
 
 import {Feature, Attribute, ValueMap} from '../../../shared/submission.model';
 import {FeatureForm} from '../subm-form.service';
+import {UserData} from "../../../../auth/user-data";
 
 @Component({
     selector: 'subm-feature-grid',
@@ -21,7 +22,7 @@ export class FeatureGridComponent implements AfterViewInit {
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
     @ViewChildren('colEl') colEls: QueryList<ElementRef>;
 
-    constructor(private rootEl: ElementRef) {}
+    constructor(private rootEl: ElementRef, private userData: UserData) {}
 
     get rows(): ValueMap[] {
         return this.featureForm.rows;


### PR DESCRIPTION
Right now the tool lacks any authorisation logic and instead hard-codes the current user's role to `User.Public`. 
Until the tool is refactored to support different user roles, all edition capabilities are restricted to non-public users, effectively disabling them for now. This is in line with the production version as of 15/1/2018.