### PR TITLE
Fixes backdrop click limbo.

### DIFF
--- a/src/app/shared/confirm-dialog.component.html
+++ b/src/app/shared/confirm-dialog.component.html
@@ -1,4 +1,5 @@
 <div class="modal fade" bsModal #staticModal="bs-modal"
+     (onHidden)="onHidden($event)"
      (onShown)="onShown()"
      tabindex="-1"
      role="dialog">

--- a/src/app/shared/confirm-dialog.component.ts
+++ b/src/app/shared/confirm-dialog.component.ts
@@ -59,13 +59,6 @@ export class ConfirmDialogComponent {
     }
 
     /**
-     * Handler for "onShown" event, triggered exactly after the modal has been fully revealed.
-     */
-    onShown(): void {
-        this.focusEl.nativeElement.focus();
-    }
-
-    /**
      * Handler for confirmation event. Notifies such confirmation with a "true" in the event stream.
      */
     ok(): void {
@@ -79,5 +72,23 @@ export class ConfirmDialogComponent {
     cancel(): void {
         this.buttonClicks.next(false);
         this.modalDirective.hide();
+    }
+
+    /**
+     * Handler for "onShown" event, triggered exactly after the modal has been fully revealed.
+     */
+    onShown(): void {
+        this.focusEl.nativeElement.focus();
+    }
+
+    /**
+     * Monitors modal dismissals and, if any of them are due to clicks on the backdrop area,
+     * it is interpreted as a cancel action.
+     * @param event - Custom modal event indicating the reason for the modal's dismissal
+     */
+    onHidden(event: ModalDirective): void {
+        if (event.dismissReason == 'backdrop-click') {
+            this.cancel();
+        }
     }
 }

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -197,7 +197,7 @@ export class SubmEditComponent implements OnInit, OnDestroy {
     /**
      * Handler for revert action. It deletes the current revision and loads the latest released version by
      * fetching the same submission again (after deletion).
-     * @param {Event} event DOM event for the click action.
+     * @param {Event} event - DOM event for the click action.
      * TODO: This produces an spurious GET request. ngOnInit needs to be split up.
      */
     onRevert(event: Event) {


### PR DESCRIPTION
Fixes the limbo state the app is left in when dismissing a confirmation modal on backdrop click.