### PR TITLE
Autocomplete for submission fields

### DIFF
--- a/src/app/shared/inline-edit.component.css
+++ b/src/app/shared/inline-edit.component.css
@@ -4,9 +4,9 @@
     height: auto;
     color: inherit;
     border: none;
-    -webkit-box-shadow: none;
-    -moz-box-shadow: none;
-    box-shadow: none;
+    -webkit-box-shadow: none !important;
+    -moz-box-shadow: none !important;
+    box-shadow: none !important;
 }
 
 /* Truncates text when not editing */

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -186,8 +186,17 @@ export class SubmEditComponent implements OnInit, OnDestroy {
         return this.subm.sectionPath(this.section.id);
     }
 
+    /**
+     * Checks that the form contains no errors. It does so with a double test to guarantee resilience:
+     * batch validator's count and a DOM-based count. The latter for errors that don't concern the form itself
+     * and therefore and not likely to be caught by the batch validator, such as repeated columns.
+     * TODO: There is already an array for row errors. Columns should have a similar one.
+     * @see {@link SubmFormComponent}
+     * @see {@link SubmissionValidator}
+     * @returns {boolean} True is there are no errors.
+     */
     get formValid(): boolean {
-        return this.errors.empty();
+        return this.errors.empty() && !this.submForm.hasError;
     }
 
     onSectionClick(section: Section): void {

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -116,20 +116,20 @@ export class SubmEditComponent implements OnInit, OnDestroy {
                 this.errors = SubmissionValidator.validate(this.subm);
 
                 //Re-validates the submission on change (including non-text updates).
-                this.subm.updates().switchMap((ue) => {
+                this.subm.updates().switchMap((event) => {
 
-                        //Inspects the original event producing the cascade of subsequent ones and saves the submission if it was triggered by a non-text update.
-                        //NOTE: Leaf nodes in the update event tree have no source.
-                        if (SubmEditComponent.watchedUpdates.indexOf(ue.leafEvent.name) > -1) {
-                            this.onChange();
-                        }
+                    //Inspects the original event producing the cascade of subsequent ones and saves the submission if it was triggered by a non-text update.
+                    //NOTE: Leaf nodes in the update event tree have no source.
+                    if (SubmEditComponent.watchedUpdates.indexOf(event.leafEvent.name) > -1) {
+                        this.onChange();
+                    }
 
-                        //Performs programmatic validation, its results being aggregated in a modal log.
-                        return SubmissionValidator.createObservable(this.subm);
+                    //Performs programmatic validation, its results being aggregated in a modal log.
+                    return SubmissionValidator.createObservable(this.subm);
 
-                    }).subscribe(errors => {
-                        this.errors = errors;
-                    });
+                }).subscribe(errors => {
+                    this.errors = errors;
+                });
 
                 //Determines the current section (in case the user navigates down to a subsection)
                 this.changeSection(this.subm.root.id);

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.css
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.css
@@ -17,7 +17,10 @@
     float: left;
 }
 .canton, .column-heading {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid #CCC;
+}
+.column-heading.has-error {
+    border-bottom-color: #C05F5D;
 }
 .canton .btn-add {
     overflow: hidden;

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -1,24 +1,36 @@
 <div class="container-fluid container-scroll" [formGroup]="featureForm.form">
     <div class="row">
         <div class="cell canton col-xs-1 col-md-1 text-center">
-            <button *ngIf="userData.isPrivileged" class="btn-add btn btn-link btn-md" type="button" tabindex="-1"
-                    [ngClass]="{'invisible': readonly}"
+            <button class="btn-add btn btn-link btn-md" type="button" tabindex="-1"
+                    [ngClass]="{'invisible': readonly || !userData.isPrivileged}"
                     [tooltip]="'Add a new ' + feature.typeName.toLowerCase() + ' attribute'"
                     container="body"
                     (click)="feature.addColumn()">
                 <i class="fa fa-plus-circle" aria-hidden="true"></i> Column
             </button>
-            {{userData.isPrivileged ? '' : '&nbsp;'}}
 
         </div><!--
-        --><div class="cell heading-cell column-heading col-xs-3 col-md-2" *ngFor="let column of columns; let idx = index">
+        --><div *ngFor="let column of columns; let idx = index" class="cell heading-cell column-heading col-xs-3 col-md-2"
+                [ngClass]="{'has-error': !column.required &&
+                                             featureForm.columnControl(column.id).invalid &&
+                                             featureForm.columnControl(column.id).touched}">
             <inline-edit
+                    placement="bottom"
+                    triggers="focus"
+                    containerClass="validation-pop text-danger"
+                    popover="Please use a unique column name"
                     [(ngModel)]="column.name"
                     emptyValue="{{'Column ' + (idx + 1)}}"
                     (remove)="feature.removeColumn(column.id)"
                     [formControl]="featureForm.columnControl(column.id)"
                     [required]="column.required"
-                    [disableEdit]="column.displayed || readonly || !userData.isPrivileged">
+                    [disableEdit]="column.displayed || readonly || !userData.isPrivileged"
+                    [typeahead]="colNames"
+                    #ahead1="bs-typeahead"
+                    unique
+                    validate-onblur
+                    (keyup.enter)="ahead1._container ? $event.stopPropagation() : return"
+            >
             </inline-edit>
         </div>
     </div>
@@ -50,8 +62,8 @@
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
                             [typeahead]="column.values"
-                            #ahead="bs-typeahead"
-                            (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
+                            #ahead2="bs-typeahead"
+                            (keyup.enter)="ahead2._container ? $event.stopPropagation() : return"
                             (async)="addOnAsync($event, rowIdx)"
                             isSmall="true"
                             validate-onblur>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -18,7 +18,7 @@
                     (remove)="feature.removeColumn(column.id)"
                     [formControl]="featureForm.columnControl(column.id)"
                     [required]="column.required"
-                    [disableEdit]="featureForm.columnType(column.id).displayed || readonly || !userData.isPrivileged">
+                    [disableEdit]="column.displayed || readonly || !userData.isPrivileged">
             </inline-edit>
         </div>
     </div>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -49,6 +49,9 @@
                             [readonly]="readonly"
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
+                            [typeahead]="column.values"
+                            #ahead="bs-typeahead"
+                            (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
                             (async)="addOnAsync($event, rowIdx)"
                             isSmall="true"
                             validate-onblur>
@@ -61,6 +64,6 @@
         [tooltip]="'Add a new ' + feature.typeName.toLowerCase()"
         container="body"
         (click)="feature.addRow()">
-    <i class="fa fa-lg {{feature.type.icon}}"></i>
-    &nbsp;Add {{feature.typeName.toLowerCase()}} row
+    <i class="fa fa-lg fa-plus-circle"></i>
+    Add {{feature.typeName.toLowerCase()}} row
 </button>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -10,6 +10,7 @@ import {
 import {Feature, Attribute, ValueMap} from '../../../shared/submission.model';
 import {FeatureForm} from '../subm-form.service';
 import {UserData} from "../../../../auth/user-data";
+import {TypeaheadDirective} from "ngx-bootstrap";
 
 @Component({
     selector: 'subm-feature-grid',
@@ -19,6 +20,7 @@ import {UserData} from "../../../../auth/user-data";
 export class FeatureGridComponent implements AfterViewInit {
     @Input() featureForm: FeatureForm;
     @Input() readonly? = false;
+    @ViewChildren('ahead') typeaheads: QueryList<TypeaheadDirective>;
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
     @ViewChildren('colEl') colEls: QueryList<ElementRef>;
 
@@ -55,6 +57,12 @@ export class FeatureGridComponent implements AfterViewInit {
 
             oldNumRows = this.featureForm.rows.length;
             oldNumCols = this.featureForm.columns.length;
+        });
+
+        //Forces all typeahead overlays are attached to the body element
+        //NOTE: Could not be done directly in the template without also modifying the container for popovers
+        this.typeaheads.forEach((typeahead) => {
+           typeahead.container = "body";
         });
     }
 

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -20,7 +20,8 @@ import {TypeaheadDirective} from "ngx-bootstrap";
 export class FeatureGridComponent implements AfterViewInit {
     @Input() featureForm: FeatureForm;
     @Input() readonly? = false;
-    @ViewChildren('ahead') typeaheads: QueryList<TypeaheadDirective>;
+    @Input() colNames: string[] = [];       //List of allowed column names out of the list specified in the default template
+    @ViewChildren('ahead1, ahead2') typeaheads: QueryList<TypeaheadDirective>;
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
     @ViewChildren('colEl') colEls: QueryList<ElementRef>;
 
@@ -59,10 +60,19 @@ export class FeatureGridComponent implements AfterViewInit {
             oldNumCols = this.featureForm.columns.length;
         });
 
-        //Forces all typeahead overlays are attached to the body element
+        //Initialises and sets every typeahead's container to the body element every time a new row/column is added.
         //NOTE: Could not be done directly in the template without also modifying the container for popovers
+        this.setTaContainer('body');
+        this.typeaheads.changes.subscribe(this.setTaContainer.bind(this, 'body'));
+    }
+
+    /**
+     * Forces all typeahead overlays to be attached to a given DOM element.
+     * @param {string} container - DOM element identifier.
+     */
+    setTaContainer(container: string) {
         this.typeaheads.forEach((typeahead) => {
-           typeahead.container = "body";
+            typeahead.container = container;
         });
     }
 

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -13,7 +13,7 @@
                           class="input-group-btn">
                           <button type="button" tabindex="-1"
                                   class="btn btn-sm btn-danger btn-flat"
-                                  (click)="featureForm.feature.removeRowAt(idx)"
+                                  (click)="feature.removeRowAt(idx)"
                                   [disabled]="!feature.canRemoveRowAt(idx)"
                                   [tooltip]="'Delete &quot;' + column.name + '&quot; entry'"
                                   placement="bottom"
@@ -32,6 +32,7 @@
                            [typeahead]="colNames"
                            unique
                            validate-onblur
+                           (keyup.enter)="$event.stopPropagation()"
                            (blur)="featureForm.columnControl(column.id).value ||
                                    featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
                 </div>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -71,8 +71,8 @@
                 [tooltip]="'Add a new ' + feature.typeName.toLowerCase()"
                 container="body"
                 (click)="feature.addColumn()">
-            <i class="fa fa-lg {{feature.type.icon}}"></i>
-            &nbsp;Add {{feature.typeName.toLowerCase()}} row
+            <i class="fa fa-lg fa-plus-circle"></i>
+            Add {{feature.typeName.toLowerCase()}} row
         </button>
     </div>
 </div>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -5,9 +5,11 @@
     </div>
     <div class="row" #rowEl *ngFor="let column of columns; let idx = index; let first = first; let last = last">
         <div class="cell col-xs-3">
-            <div class="form-group key-field">
+            <div class="form-group key-field"
+                 [ngClass]="{'has-error': !column.required && featureForm.columnControl(column.id).invalid &&
+                                          featureForm.columnControl(column.id).touched}">
                 <div class="input-group">
-                    <span *ngIf="!readonly && !column.required && !featureForm.columnType(column.id).displayed"
+                    <span *ngIf="!readonly && !column.required && !column.displayed"
                           class="input-group-btn">
                           <button type="button" tabindex="-1"
                                   class="btn btn-sm btn-danger btn-flat"
@@ -19,11 +21,17 @@
                                <i class="fa fa-trash-o"></i>
                           </button>
                     </span>
-                    <input type="text"
-                           class="form-control input-sm"
+                    <input type="text" class="form-control input-sm"
+                           placement="{{first && !last ? 'bottom' : 'top'}}"
+                           triggers="focus"
+                           containerClass="validation-pop text-danger"
+                           popover="Please use a unique key name"
                            [(ngModel)]="column.name"
                            [formControl]="featureForm.columnControl(column.id)"
-                           [readonly]="readonly || column.required || featureForm.columnType(column.id).displayed"
+                           [readonly]="readonly || column.required || column.displayed"
+                           [typeahead]="colNames"
+                           unique
+                           validate-onblur
                            (blur)="featureForm.columnControl(column.id).value ||
                                    featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
                 </div>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -5,8 +5,10 @@
     </div>
     <div class="row" #rowEl *ngFor="let column of columns; let idx = index; let first = first; let last = last">
         <div class="cell col-xs-3">
+            <!-- NOTE: required columns cannot be edited => will never be the one causing name collision -->
             <div class="form-group key-field"
-                 [ngClass]="{'has-error': !column.required && featureForm.columnControl(column.id).invalid &&
+                 [ngClass]="{'has-error': !column.required &&
+                                          featureForm.columnControl(column.id).invalid &&
                                           featureForm.columnControl(column.id).touched}">
                 <div class="input-group">
                     <span *ngIf="!readonly && !column.required && !column.displayed"

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -26,13 +26,15 @@
                            triggers="focus"
                            containerClass="validation-pop text-danger"
                            popover="Please use a unique key name"
-                           [(ngModel)]="column.name"
+                           [ngModel]="column.name"
                            [formControl]="featureForm.columnControl(column.id)"
                            [readonly]="readonly || column.required || column.displayed"
                            [typeahead]="colNames"
+                           #ahead1="bs-typeahead"
                            unique
                            validate-onblur
-                           (keyup.enter)="$event.stopPropagation()"
+                           (keyup.enter)="ahead1._container ? $event.stopPropagation() : return"
+                           (change)="column.name = $event.target.value"
                            (blur)="featureForm.columnControl(column.id).value ||
                                    featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
                 </div>
@@ -52,7 +54,10 @@
                             [required]="column.required"
                             isSmall="true"
                             [formControl]="featureForm.rowValueControl(0,column.id)"
-                            validate-onblur>
+                            [typeahead]="column.values"
+                            #ahead2="bs-typeahead"
+                            validate-onblur
+                            (keyup.enter)="ahead2._container ? $event.stopPropagation() : return">
                 </subm-field>
             </div>
         </div>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.ts
@@ -13,9 +13,9 @@ import {FeatureForm} from '../subm-form.service';
     styleUrls: ['./feature-list.component.css']
 })
 export class FeatureListComponent implements AfterViewInit {
-    @Input() featureForm: FeatureForm;
-    @Input() readonly?: boolean = false;
-    @Input() colNames: string[] = [];
+    @Input() featureForm: FeatureForm;      //Reactive data structure for the form containing this feature
+    @Input() readonly?: boolean = false;    //Flag for features that cannot be edited (e.g. sent state for submissions)
+    @Input() colNames: string[] = [];       //List of allowed column names out of the list specified in the default template
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
 
     get columns(): Attribute[] {

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.ts
@@ -15,6 +15,7 @@ import {FeatureForm} from '../subm-form.service';
 export class FeatureListComponent implements AfterViewInit {
     @Input() featureForm: FeatureForm;
     @Input() readonly?: boolean = false;
+    @Input() colNames: string[] = [];
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
 
     get columns(): Attribute[] {

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -22,6 +22,7 @@
     <div class="panel-body" #featureEl>
         <subm-feature-grid *ngIf="!feature.singleRow"
                            [featureForm]="featureForm"
+                           [colNames]="uniqueColNames"
                            [readonly]="readonly">
         </subm-feature-grid>
         <subm-feature-list *ngIf="feature.singleRow"

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -26,7 +26,7 @@
         </subm-feature-grid>
         <subm-feature-list *ngIf="feature.singleRow"
                            [featureForm]="featureForm"
-                           [colNames]="colNames"
+                           [colNames]="uniqueColNames"
                            [readonly]="readonly">
         </subm-feature-list>
     </div>

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -26,6 +26,7 @@
         </subm-feature-grid>
         <subm-feature-list *ngIf="feature.singleRow"
                            [featureForm]="featureForm"
+                           [colNames]="colNames"
                            [readonly]="readonly">
         </subm-feature-list>
     </div>

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -19,14 +19,15 @@ export class SubmFeatureComponent implements OnInit {
     @Input() isMenu?: boolean = true;
     @ViewChild('featureEl') featureEl: ElementRef;
 
-    actions: any[] = [];
-    errorNum: number = 0;
-
+    private actions: any[] = [];
+    private errorNum: number = 0;
+    private colTypeNames: string[];
 
     constructor(private changeRef: ChangeDetectorRef) {}
 
     /**
-     * Defines the actions of the feature's menu according to its type (list or not).
+     * Defines the actions of the feature's menu according to its type (list or not). It also gets the type names
+     * of all possible columns just once.
      */
     ngOnInit() {
         this.actions.push({
@@ -39,10 +40,22 @@ export class SubmFeatureComponent implements OnInit {
                 invoke: () => this.feature.addRow()
             });
         }
+        this.colTypeNames = this.feature.type.columnTypes.map(type => type.name);
     }
 
     get feature(): Feature {
         return this.featureForm === undefined ? undefined : this.featureForm.feature;
+    }
+
+    //Gets the names of all columns from the list of column types.
+    get colNames(): string[] {
+
+        if (this.feature === undefined) {
+            return [];
+
+        } else {
+            return this.colTypeNames;
+        }
     }
 
     /**

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -51,8 +51,7 @@ export class SubmFeatureComponent implements OnInit {
      * Gets the names of allowed new column names. Since they have to be unique, it takes all columns from
      * the list of column types and removes the names for the current columns.
      */
-    get colNames(): string[] {
-        const currColNames = this.featureForm.columns.map(column => column.name);
+    get uniqueColNames(): string[] {
 
         //Feature not loaded yet => returns no column names.
         if (this.feature === undefined) {
@@ -60,7 +59,7 @@ export class SubmFeatureComponent implements OnInit {
 
         //Feature loaded => gets only uniques column names.
         } else {
-            return this.colTypeNames.filter(name => currColNames.indexOf(name) == -1);
+            return this.colTypeNames.filter(name => this.feature.colNames.indexOf(name) == -1);
         }
     }
 

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -47,14 +47,20 @@ export class SubmFeatureComponent implements OnInit {
         return this.featureForm === undefined ? undefined : this.featureForm.feature;
     }
 
-    //Gets the names of all columns from the list of column types.
+    /**
+     * Gets the names of allowed new column names. Since they have to be unique, it takes all columns from
+     * the list of column types and removes the names for the current columns.
+     */
     get colNames(): string[] {
+        const currColNames = this.featureForm.columns.map(column => column.name);
 
+        //Feature not loaded yet => returns no column names.
         if (this.feature === undefined) {
             return [];
 
+        //Feature loaded => gets only uniques column names.
         } else {
-            return this.colTypeNames;
+            return this.colTypeNames.filter(name => currColNames.indexOf(name) == -1);
         }
     }
 

--- a/src/app/submission/edit/subm-form/subm-form.component.ts
+++ b/src/app/submission/edit/subm-form/subm-form.component.ts
@@ -1,5 +1,5 @@
 import {
-    Component,
+    Component, ElementRef,
     Input,
     OnChanges
 } from '@angular/core';
@@ -21,11 +21,24 @@ export class SubmFormComponent implements OnChanges {
     @Input() readonly: boolean;
 
     sectionForm: SectionForm;
+    hasError: boolean = false;
 
-    constructor(private submFormService: SubmFormService) {}
+    private hasErrorEls: NodeListOf<Element>;
+
+    constructor(private submFormService: SubmFormService, private rootEl: ElementRef) {}
 
     ngOnChanges(): void {
         this.sectionForm = this.submFormService.createForm(this.section);
+    }
+
+    ngDoCheck(): void {
+        if (this.hasErrorEls) {
+            this.hasError = this.hasErrorEls.length != 0;
+        }
+    }
+
+    ngAfterViewInit(): void {
+        this.hasErrorEls = this.rootEl.nativeElement.getElementsByClassName('has-error');
     }
 
     /**

--- a/src/app/submission/edit/subm-form/subm-form.service.ts
+++ b/src/app/submission/edit/subm-form/subm-form.service.ts
@@ -431,14 +431,14 @@ export class FeatureForm {
     private updateColumnControls(ue?: UpdateEvent): void {
         this._columns = this.feature.columns;
 
-        if (ue && ue.name === 'column_remove') {
-            this.removeColumnControl(ue.value.id);
+        if (ue && ue.source.name === 'column_remove') {
+            this.removeColumnControl(ue.source.value.id);
             return;
         }
 
         let toAdd: Attribute[] = this.columns;
-        if (ue && ue.name === 'column_add') {
-            toAdd = [this.columns[ue.value.index]];
+        if (ue && ue.source.name === 'column_add') {
+            toAdd = [this.columns[ue.source.value.index]];
         }
 
         toAdd.forEach(

--- a/src/app/submission/edit/subm-form/subm-form.service.ts
+++ b/src/app/submission/edit/subm-form/subm-form.service.ts
@@ -367,29 +367,25 @@ export class FeatureForm {
 
     private removeColumnControl(colId: string) {
         this.columnsFormGroup.removeControl(colId);
-        this.rows.forEach(
-            (row, rowIndex) => {
-                (<FormGroup>this.rowsFormArray.at(rowIndex)).removeControl(colId);
+        this.rows.forEach((row, rowIndex) => {
+            (<FormGroup>this.rowsFormArray.at(rowIndex)).removeControl(colId);
 
-                //Removes the error entry in the current row for the deleted column
-                delete this.rowErrors[rowIndex][colId];
-            }
-        );
+            //Removes the error entry in the current row for the deleted column
+            delete this.rowErrors[rowIndex][colId];
+        });
     }
 
     private addColumnControl(column: Attribute) {
         const t = this.feature.type.getColumnType(column.name);
         const colValidators = [Validators.required];
         this.columnsFormGroup.addControl(column.id, new FormControl(column.name, colValidators));
-        this.rows.forEach(
-            (row, rowIndex) => {
-                const fg = (<FormGroup>this.rowsFormArray.at(rowIndex));
-                this.addRowValueControl(fg, column.id, row, t);
+        this.rows.forEach((row, rowIndex) => {
+            const fg = (<FormGroup>this.rowsFormArray.at(rowIndex));
+            this.addRowValueControl(fg, column.id, row, t);
 
-                //Regenerates the field errors for the whole current row
-                this.addRowErrors(fg);
-            }
-        );
+            //Regenerates the field errors for the whole current row
+            this.addRowErrors(fg);
+        });
     }
 
     private removeRowArray(index: number) {

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -17,7 +17,10 @@
                 <template tabHeading>
                     Check
                     <span *ngIf="errors.total()" class="badge badge-corner"
-                          [ngClass]="{'badge-danger': numPending}">{{errors.total()}}</span>
+                          [ngClass]="{'badge-half-danger': numPending > 0 && numPending < errors.total(),
+                                      'badge-danger': numPending == errors.total()}">
+                        {{errors.total()}}
+                    </span>
                 </template>
             </tab>
             <tab heading="Add"

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -84,7 +84,7 @@
                 </button>
             </li>
         </form>
-        <li *ngIf="!isStatus && !editing" class="text-right">
+        <li *ngIf="!isStatus && !editing && userData.isPrivileged" class="text-right">
             <button *ngIf="!collapsed" class="advanced-btn btn btn-link btn-sm"
                     (click)="toggleAdvanced()">
                 <i class="fa fa-chevron-circle-right" aria-hidden="true"

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.ts
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.ts
@@ -25,6 +25,7 @@ import { ConfirmDialogComponent } from 'app/shared/index';
 import { SectionType } from '../../shared/submission-type.model';
 import {SubmValidationErrors} from "../../shared/submission.validator";
 import {FieldControl} from "../subm-form/subm-form.service";
+import {UserData} from "../../../auth/user-data";
 
 /**
  * Submission item class aggregating its corresponding feature with UI-relevant metadata. It enables
@@ -174,6 +175,8 @@ export class SubmSideBarComponent implements OnChanges {
     numPending: number = 0;          //number of modified fields still pending review (still invalid)
 
     private subscr: Subscription;
+
+    constructor(private userData: UserData) {}
 
     /**
      * Updates the list of type items whenever a feature is added or removed.

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -2,15 +2,16 @@ export const DefaultTemplate = {
     'name': 'DeafultTemplate',
     'sectionType': {
         'name': 'Study',
-        'required': true,
         'annotationsType': {
             'title': 'Describe your study',
             'description': 'Provide any supplementary details of the study that may help discover and/or interpret it',
             'icon': 'fa-tag',
+            'required': true,
             'columnTypes': [
                 {
                     'name': 'Organism',
-                    'valueType': 'text'
+                    'valueType': 'text',
+                    'required': true
                 },
                 {
                     'name': 'Experimental design',

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -9,7 +9,8 @@ export const DefaultTemplate = {
             'columnTypes': [
                 {
                     'name': 'Organism',
-                    'valueType': 'text'
+                    'valueType': 'text',
+                    'values': ['Homo sapiens', 'Gallus gallus', 'Rattus norvegicus', 'Mus musculus', 'Arabidopsis thaliana', 'Escherichia coli', 'Danio rerio']
                 },
                 {
                     'name': 'Experimental design',

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -68,6 +68,7 @@ export const DefaultTemplate = {
                     {
                         'name': 'Organisation',
                         'valueType': 'text',
+                        'values': ['European Bioinformatics Institute', 'Wellcome Sanger Institute', 'Francis Crick Institute', 'MRC Laboratory of Molecular Biology'],
                         'required': true
                     },
                     {

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -6,12 +6,10 @@ export const DefaultTemplate = {
             'title': 'Describe your study',
             'description': 'Provide any supplementary details of the study that may help discover and/or interpret it',
             'icon': 'fa-tag',
-            'required': true,
             'columnTypes': [
                 {
                     'name': 'Organism',
-                    'valueType': 'text',
-                    'required': true
+                    'valueType': 'text'
                 },
                 {
                     'name': 'Experimental design',
@@ -100,6 +98,50 @@ export const DefaultTemplate = {
                 ]
             },
             {
+                'name': 'File',
+                'title': 'Add Files',
+                'description': 'List the data files for the study and describe their respective scopes',
+                'icon': 'fa-file',
+                'columnTypes': [
+                    {
+                        'name': 'Path',
+                        'valueType': 'file',
+                        'required': true
+                    },
+                    {
+                        'name': 'Description',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
+                        'name': 'Type',
+                        'valueType': 'text'
+                    }
+                ]
+            },
+            {
+                'name': 'Link',
+                'title': 'Add Links',
+                'description': 'Provide links to any additional documentation that may be of relevance',
+                'icon': 'fa-link',
+                'columnTypes': [
+                    {
+                        'name': 'URL',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
+                        'name': 'Description',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
+                        'name': 'Type',
+                        'valueType': 'text'
+                    }
+                ]
+            },
+            {
                 'name': 'Publication',
                 'title': 'Add Publications',
                 'description': 'Add the details of publications relevant or complementary to the study',
@@ -147,50 +189,6 @@ export const DefaultTemplate = {
                         'name': 'DOI',
                         'valueType': 'text'
                     },
-                ]
-            },
-            {
-                'name': 'Link',
-                'title': 'Add Links',
-                'description': 'Provide links to any additional documentation that may be of relevance',
-                'icon': 'fa-link',
-                'columnTypes': [
-                    {
-                        'name': 'URL',
-                        'valueType': 'text',
-                        'required': true
-                    },
-                    {
-                        'name': 'Description',
-                        'valueType': 'text',
-                        'required': true
-                    },
-                    {
-                        'name': 'Type',
-                        'valueType': 'text'
-                    }
-                ]
-            },
-            {
-                'name': 'File',
-                'title': 'Add Files',
-                'description': 'List the data files for the study and describe their respective scopes',
-                'icon': 'fa-file',
-                'columnTypes': [
-                    {
-                        'name': 'Path',
-                        'valueType': 'file',
-                        'required': true
-                    },
-                    {
-                        'name': 'Description',
-                        'valueType': 'text',
-                        'required': true
-                    },
-                    {
-                        'name': 'Type',
-                        'valueType': 'text'
-                    }
                 ]
             }
         ]

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -20,7 +20,6 @@ class BaseType {
             return;
         }
 
-        //TODO: scope check is not working. Why?
         if (scope.has(name)) {
             console.warn(`Error: Type with name ${name} already exists in the scope`);
             return;

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -55,8 +55,8 @@ class BaseType {
     }
 }
 
-/* Fields are always required by default. User can't add/change/delete fields. Only changing its value is allowed.
- * In PageTab it's selected by name attribute from an 'attributes' section.
+/* Top-level fields are always required by default. User can't add/change/delete fields. Only changing
+ * its value is allowed. In PageTab, it's selected by name attribute from an 'attributes' section.
  */
 export type ValueType = 'text' | 'textblob' | 'date' | 'file';
 
@@ -154,11 +154,22 @@ export class FeatureType extends BaseType {
 
     }
 
-    getColumnType(name: string): ColumnType {
+    /**
+     * Gets the column type corresponding to a certain given name, creating a new one if so required.
+     * @param {string} name - Name of the column whose type object is required.
+     * @param {boolean} [isCreate = true] - Flag to enable the automatic creation of types for unknown columns.
+     * @returns {ColumnType} Type object for the searched column. Null if creation disabled.
+     */
+    getColumnType(name: string, isCreate: boolean = true): ColumnType {
         if (this.columnScope.has(name)) {
             return this.columnScope.get(name);
         }
-        return ColumnType.createDefault(name, this.columnScope);
+
+        if (isCreate) {
+            return ColumnType.createDefault(name, this.columnScope);
+        }
+
+        return null;
     }
 }
 
@@ -176,6 +187,7 @@ export class ColumnType extends BaseType {
     readonly required: boolean;     //required data-wise: its fields should have data associated with it to be valid
     readonly displayed: boolean;    //required render-wise: should be visually available regardless of its fields being required or not
     readonly valueType: ValueType;  //type of data for the fields under this column
+    readonly values: string[];      //suggested values for the field
 
     static createDefault(name: string, scope?: Map<string, any>): ColumnType {
         return new ColumnType(name, undefined, scope);
@@ -188,6 +200,7 @@ export class ColumnType extends BaseType {
         this.valueType = other.valueType || 'text';
         this.required = other.required === true;
         this.displayed = other.displayed || false;
+        this.values = other.values || [];
     }
 }
 

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -84,11 +84,15 @@ export class Attribute extends HasUpdates<UpdateEvent> {
         this.notify(new UpdateEvent('name', name));
     }
 
-    updateType(type: ColumnType) {
-        this.required = type.required;
-        this.displayed = type.displayed;
-        this.valueType = type.valueType;
-        this.values = type.values;
+    /**
+     * Changes the type properties of the column to a given set.
+     * @param {ColumnType} colType - New type values for the column.
+     */
+    updateType(colType: ColumnType) {
+        this.required = colType.required;
+        this.displayed = colType.displayed;
+        this.valueType = colType.valueType;
+        this.values = colType.values;
     }
 }
 
@@ -439,6 +443,11 @@ export class Feature extends HasUpdates<UpdateEvent> {
         }
     }
 
+    /**
+     * Handler for column name updates. It refreshes the type properties of a given column according to name.
+     * @param {string} newName - Updated column name.
+     * @param {number} colIndex - Index of the updated column.
+     */
     onColumnRename(newName: string, colIndex: number) {
         this._columns.at(colIndex).updateType(this.type.getColumnType(newName));
     }

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -56,13 +56,15 @@ export class UpdateEvent {
 export class Attribute extends HasUpdates<UpdateEvent> {
     readonly id: string;
     readonly required: boolean;
+    readonly displayed: boolean;
     readonly valueType: ValueType;
 
     private _name: string;
 
-    constructor(name: string = '', required: boolean = false, valueType: ValueType = 'text') {
+    constructor(name: string = '', required: boolean = false, displayed: boolean = false, valueType: ValueType = 'text') {
         super();
         this.required = required;
+        this.displayed = displayed;
         this.valueType = valueType;
         this._name = name;
         this.id = `attr_${nextId()}`;
@@ -286,7 +288,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
 
         type.columnTypes.forEach(ct => {
             if (ct.required || ct.displayed) {
-                this.addColumn(ct.name, ct.required, ct.valueType);
+                this.addColumn(ct.name, ct.required, ct.displayed, ct.valueType);
             }
         });
 
@@ -389,7 +391,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
         });
     }
 
-    addColumn(name?: string, required?: boolean, valueType?: ValueType): Attribute {
+    addColumn(name?: string, required?: boolean, displayed?: boolean, valueType?: ValueType): Attribute {
         let defColName = ' ' + (this.colSize() + 1);
         let col;
 
@@ -399,7 +401,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
         } else {
             defColName = 'Column' + defColName;
         }
-        col = new Attribute(name || defColName, required, valueType);
+        col = new Attribute(name || defColName, required, displayed, valueType);
 
         //Updates row and column maps
         this._rows.addKey(col.id);

--- a/src/app/submission/shared/unique.directive.ts
+++ b/src/app/submission/shared/unique.directive.ts
@@ -55,10 +55,10 @@ export class UniqueValidator implements Validator {
  */
 function uniqueValidatorFactory(): ValidatorFn {
     return (control: FormControl) => {
-        const controls = control.parent.controls; console.log(control); console.log(controls);
+        const controls = control.parent.controls;
         const values = Object.keys(controls).map(controlKey => controls[controlKey].value);
         const valueSet = new Set(values);
-        let isValid = false; console.log(control.value + " " + values);
+        let isValid = false;
 
         //If all values of all form controls are unique, the present control must be valid
         //NOTE: Set conversion drops any duplicated entries

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -254,6 +254,12 @@ input[readonly], textarea[readonly] {
   top: -7px;
   right: -7px;
 }
+.badge-half-danger {
+  background: -webkit-linear-gradient(to right, #777777 49%, @brand-danger 50%, @brand-danger 100%);
+  background: -o-linear-gradient(to right, #777777 49%, @brand-danger 50%, @brand-danger 100%);
+  background: -moz-linear-gradient(to right, #777777 49%, @brand-danger 50%, @brand-danger 100%);
+  background: linear-gradient(to right, #777777 49%, @brand-danger 50%, @brand-danger 100%);
+}
 .badge-danger {
   background: @brand-danger !important;
 }


### PR DESCRIPTION
Adds a typeahead to both column and data fields in the submission edit view. Additionally, it checks for uniqueness of column values, showing a validation popover on focus –in line with validation everywhere else– and blocking submission if applicable.