### PR TITLE
HeCaToS, column filters and other improvements

### DIFF
--- a/src/app/auth/user-data.ts
+++ b/src/app/auth/user-data.ts
@@ -67,7 +67,7 @@ export class UserData {
      * @returns {UserRole} Public (hard-coded for the moment).
      */
     get role(): UserRole {
-        return UserRole.Public;
+        return UserRole.User;
     }
 
     /**

--- a/src/app/submission-shared/date-input.component.html
+++ b/src/app/submission-shared/date-input.component.html
@@ -4,6 +4,7 @@
     <input type="text" class="form-control" readonly
            bsDatepicker
            (bsValueChange)="onPickerSet($event)"
+           (onShown)="onPickerShown()"
            [ngModel]="dateValue"
            [required]="required"
            #dp="bsDatepicker">

--- a/src/app/submission-shared/date-input.component.ts
+++ b/src/app/submission-shared/date-input.component.ts
@@ -34,7 +34,7 @@ import {AppConfig} from "../app.config";
  * It allows the display format for the date to be different to the transactional one if needed (the latter is
  * hard-coded to ISO 8601 YYYY-MM-DD).
  * NOTE: Contrary to what its name suggests, DatePicker's "bsValueChange" output event is triggered every time
- * a date is set, NOT on change exclusively.
+ * a date is set, NOT on value change exclusively.
  * @see {@link https://valor-software.com/ngx-bootstrap/old/1.9.3/#/datepicker}
  * @see {@link ControlValueAccessor}
  */
@@ -126,6 +126,15 @@ export class DateInputComponent implements ControlValueAccessor {
             this.onChange(formatDate(this.dateValue));
             isChange && this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
         }
+    }
+
+    /**
+     * Prevents any click events from bubbling beyond the date picker to avoid conflict with any external listeners.
+     */
+    onPickerShown() {
+        document.querySelector('.bs-datepicker-container').addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
     }
 
     /**

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.html
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.html
@@ -46,7 +46,7 @@
                     </option>
                 </select>
             </div>
-            <div class="form-group">
+            <div *ngIf="isBusy || projectsToAttachTo.length" class="form-group">
                 <label class="control-label">Projects</label>
                 <span class="text-muted pull-right"><i>Optional</i></span>
                 <ul *ngIf="model.projects.length > 0">

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -190,7 +190,7 @@ export class SubmEditComponent implements OnInit, OnDestroy {
      * Checks that the form contains no errors. It does so with a double test to guarantee resilience:
      * batch validator's count and a DOM-based count. The latter for errors that don't concern the form itself
      * and therefore and not likely to be caught by the batch validator, such as repeated columns.
-     * TODO: There is already an array for row errors. Columns should have a similar one.
+     * TODO: This is temporary. There is already an array for row errors. Columns should have a similar one.
      * @see {@link SubmFormComponent}
      * @see {@link SubmissionValidator}
      * @returns {boolean} True is there are no errors.

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -26,11 +26,10 @@
                     [required]="column.required"
                     [disableEdit]="column.displayed || readonly || !userData.isPrivileged"
                     [typeahead]="colNames"
-                    #ahead1="bs-typeahead"
+                    #ahead="bs-typeahead"
                     unique
                     validate-onblur
-                    (keyup.enter)="ahead1._container ? $event.stopPropagation() : return"
-            >
+                    (keyup.enter)="ahead._container ? $event.stopPropagation() : return">
             </inline-edit>
         </div>
     </div>
@@ -55,15 +54,12 @@
                             triggers="focus"
                             containerClass="validation-pop text-danger"
                             popover="{{featureForm.rowErrors[rowIdx][column.id]}}"
-                            [name]="column.name"
                             [type]="column.valueType"
                             [(ngModel)]="row.valueFor(column.id).value"
                             [readonly]="readonly"
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
-                            [typeahead]="column.values"
-                            #ahead2="bs-typeahead"
-                            (keyup.enter)="ahead2._container ? $event.stopPropagation() : return"
+                            [autosuggest]="column.values"
                             (async)="addOnAsync($event, rowIdx)"
                             isSmall="true"
                             validate-onblur>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -26,8 +26,10 @@
                     [required]="column.required"
                     [disableEdit]="column.displayed || readonly || !userData.isPrivileged"
                     [typeahead]="colNames"
+                    [typeaheadMinLength]="0"
+                    [typeaheadOptionsLimit]="15"
                     #ahead="bs-typeahead"
-                    unique
+                    [unique]="feature.uniqueCols"
                     validate-onblur
                     (keyup.enter)="ahead._container ? $event.stopPropagation() : return">
             </inline-edit>
@@ -60,6 +62,7 @@
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
                             [autosuggest]="column.values"
+                            [suggestLength]="15"
                             (async)="addOnAsync($event, rowIdx)"
                             isSmall="true"
                             validate-onblur>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -21,7 +21,7 @@ export class FeatureGridComponent implements AfterViewInit {
     @Input() featureForm: FeatureForm;
     @Input() readonly? = false;
     @Input() colNames: string[] = [];       //List of allowed column names out of the list specified in the default template
-    @ViewChildren('ahead1, ahead2') typeaheads: QueryList<TypeaheadDirective>;
+    @ViewChildren('ahead') typeaheads: QueryList<TypeaheadDirective>;
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
     @ViewChildren('colEl') colEls: QueryList<ElementRef>;
 

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -32,8 +32,10 @@
                            [formControl]="featureForm.columnControl(column.id)"
                            [readonly]="readonly || column.required || column.displayed"
                            [typeahead]="colNames"
+                           [typeaheadMinLength]="0"
+                           [typeaheadOptionsLimit]="15"
                            #ahead="bs-typeahead"
-                           unique
+                           [unique]="feature.uniqueCols"
                            validate-onblur
                            (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
                            (change)="column.name = $event.target.value"
@@ -57,6 +59,7 @@
                             isSmall="true"
                             [formControl]="featureForm.rowValueControl(0,column.id)"
                             [autosuggest]="column.values"
+                            [suggestLength]="15"
                             validate-onblur>
                 </subm-field>
             </div>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -32,10 +32,10 @@
                            [formControl]="featureForm.columnControl(column.id)"
                            [readonly]="readonly || column.required || column.displayed"
                            [typeahead]="colNames"
-                           #ahead1="bs-typeahead"
+                           #ahead="bs-typeahead"
                            unique
                            validate-onblur
-                           (keyup.enter)="ahead1._container ? $event.stopPropagation() : return"
+                           (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
                            (change)="column.name = $event.target.value"
                            (blur)="featureForm.columnControl(column.id).value ||
                                    featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
@@ -56,10 +56,8 @@
                             [required]="column.required"
                             isSmall="true"
                             [formControl]="featureForm.rowValueControl(0,column.id)"
-                            [typeahead]="column.values"
-                            #ahead2="bs-typeahead"
-                            validate-onblur
-                            (keyup.enter)="ahead2._container ? $event.stopPropagation() : return">
+                            [autosuggest]="column.values"
+                            validate-onblur>
                 </subm-field>
             </div>
         </div>

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -22,12 +22,12 @@
     <div class="panel-body" #featureEl>
         <subm-feature-grid *ngIf="!feature.singleRow"
                            [featureForm]="featureForm"
-                           [colNames]="uniqueColNames"
+                           [colNames]="allowedCols"
                            [readonly]="readonly">
         </subm-feature-grid>
         <subm-feature-list *ngIf="feature.singleRow"
                            [featureForm]="featureForm"
-                           [colNames]="uniqueColNames"
+                           [colNames]="allowedCols"
                            [readonly]="readonly">
         </subm-feature-list>
     </div>

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -22,6 +22,7 @@ export class SubmFeatureComponent implements OnInit {
     private actions: any[] = [];
     private errorNum: number = 0;
     private colTypeNames: string[];
+    private allowedCols: string[];
 
     constructor(private changeRef: ChangeDetectorRef) {}
 
@@ -51,7 +52,7 @@ export class SubmFeatureComponent implements OnInit {
      * Gets the names of allowed new column names. Since they have to be unique, it takes all columns from
      * the list of column types and removes the names for the current columns.
      */
-    get uniqueColNames(): string[] {
+    uniqueColNames(): string[] {
 
         //Feature not loaded yet => returns no column names.
         if (this.feature === undefined) {
@@ -69,6 +70,7 @@ export class SubmFeatureComponent implements OnInit {
     ngDoCheck(): void {
         if (this.featureEl) {
             this.errorNum = this.featureEl.nativeElement.getElementsByClassName('has-error').length;
+            this.allowedCols = this.uniqueColNames();
             this.changeRef.detectChanges();
         }
     }

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -49,8 +49,7 @@ export class SubmFeatureComponent implements OnInit {
     }
 
     /**
-     * Gets the names of allowed new column names. Since they have to be unique, it takes all columns from
-     * the list of column types and removes the names for the current columns.
+     * It takes all columns from the list of column types and removes the names for the current columns.
      */
     uniqueColNames(): string[] {
 
@@ -70,7 +69,13 @@ export class SubmFeatureComponent implements OnInit {
     ngDoCheck(): void {
         if (this.featureEl) {
             this.errorNum = this.featureEl.nativeElement.getElementsByClassName('has-error').length;
-            this.allowedCols = this.uniqueColNames();
+
+            if (this.feature.uniqueCols) {
+                this.allowedCols = this.uniqueColNames();
+            } else {
+                this.allowedCols = this.colTypeNames;
+            }
+
             this.changeRef.detectChanges();
         }
     }

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -7,14 +7,11 @@
        [(ngModel)]="value"
        [readonly]="readonly"
        [required]="required"
-       (blur)="onBlur()">
+       (blur)="onBlur()"
+       [typeahead]="autosuggest"
+       #ahead="bs-typeahead"
+       (keyup.enter)="ahead._container ? $event.stopPropagation() : return">
 
-<!--
-           [typeahead]="typeaheadAttrValues(attr.name)"
-           typeaheadAppendToBody="true"
-           typeaheadMinLength="0"
-           typeaheadOptionsLimit="30"
--->
 <date-input
         *ngIf="type === 'date'"
         [(ngModel)]="value"

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -9,6 +9,8 @@
        [required]="required"
        (blur)="onBlur()"
        [typeahead]="autosuggest"
+       [typeaheadMinLength]="suggestThreshold"
+       [typeaheadOptionsLimit]="suggestLength"
        #ahead="bs-typeahead"
        (keyup.enter)="ahead._container ? $event.stopPropagation() : return">
 

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -26,14 +26,14 @@ export class SubmFieldComponent implements ControlValueAccessor {
     private onChange: any = (_:any) => {};      //placeholder for handler propagating changes outside the custom control
     private onTouched: any = () => {};          //placeholder for handler after the control has been "touched"
 
-    private _value = '';
+    private _value = '';                        //internal data model for the field's value
     private isOverflow: boolean = false;        //indicates if the text content is longer than the field itself.
 
-    @Input() name: string;
-    @Input() type: string;
-    @Input() readonly: boolean;
-    @Input() required: boolean;
-    @Input() formControl: FieldControl;
+    @Input() type: string;                      //type of field: text, date, pubmedid, orcid...
+    @Input() readonly: boolean;                 //if true, the field will be rendered but its value cannot be changed
+    @Input() required: boolean;                 //if true, the field must not be left blank
+    @Input() formControl: FieldControl;         //reactive control associated with this field
+    @Input() autosuggest: any[] = [];           //typeahead list of suggested values
     @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
 
     @Output() async: EventEmitter<any> = new EventEmitter<any>();  //signals availability of asynchronous attributes

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -33,8 +33,11 @@ export class SubmFieldComponent implements ControlValueAccessor {
     @Input() readonly: boolean;                 //if true, the field will be rendered but its value cannot be changed
     @Input() required: boolean;                 //if true, the field must not be left blank
     @Input() formControl: FieldControl;         //reactive control associated with this field
-    @Input() autosuggest: any[] = [];           //typeahead list of suggested values
     @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
+    @Input() autosuggest: any[] = [];           //typeahead list of suggested values
+    @Input() suggestThreshold: number = 0;      //the typeahead is meant to act as a reminder of other fields too
+    @Input() suggestLength: number = 30;        //max number of suggested values to be displayed at once
+
 
     @Output() async: EventEmitter<any> = new EventEmitter<any>();  //signals availability of asynchronous attributes
 

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -11,7 +11,7 @@
                 <span *ngIf="get(field.id).invalid && get(field.id).touched">
                     {{sectionForm.formErrors[field.id] ? sectionForm.formErrors[field.id] : ''}}
                 </span>
-                <span [hidden]="readonly || get(field.id).invalid && get(field.id).touched" class="text-muted">
+                <span class="text-muted" [hidden]="readonly || get(field.id).invalid && get(field.id).touched">
                      <span *ngIf="(get(field.id, 'minlength') > 0) && (get(field.id, 'maxlength') < 0)">
                          (at least {{get(field.id, 'minlength')}}
                      </span>
@@ -33,11 +33,11 @@
                 </span>
                 <subm-field class="subm-field"
                     [type]="field.valueType"
-                    [name]="field.name"
                     [readonly]="readonly"
                     [required]="field.type.required"
                     [(ngModel)]="field.value"
                     [formControl]="get(field.id)"
+                    [autosuggest]="field.type.values"
                     validate-onblur>
                 </subm-field>
             </div>

--- a/src/app/submission/edit/subm-navbar/subm-validation-errors.component.html
+++ b/src/app/submission/edit/subm-navbar/subm-validation-errors.component.html
@@ -5,7 +5,7 @@
             aria-label="Close">
         <span aria-hidden="true">&times;</span>
     </button>
-    <h4 class="modal-title">Log: {{errors.total()}} error{{errors.total() > 1 ? 's' : ''}}</h4>
+    <h4 class="modal-title">Validation log: {{errors.total()}} error{{errors.total() > 1 ? 's' : ''}}</h4>
 </div>
 <div class="modal-body">
     <ul class="list-group">

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.ts
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.ts
@@ -351,7 +351,6 @@ export class SubmSideBarComponent implements OnChanges {
 
     /**
      * Removes the submission item from the list of controls and marks it for deletion.
-     * It also makes sure that validation is consistent with current input values.
      * @param {Event} event - Click event object.
      * @param {FormControl[]} controls - Array of controls making up the component's form.
      * @param {string} nameInput - Name of the input control corresponding to the item being removed.
@@ -360,12 +359,7 @@ export class SubmSideBarComponent implements OnChanges {
     onItemDelete(event: Event, nameInput: string, controls: FormControl[], itemIdx: number): void {
         event.preventDefault();
         this.items.delete(itemIdx);
-
-        //Updates validity after deletion to avoid inconsistencies, especially regarding the uniqueness test.
         delete controls[nameInput];
-        Object.keys(controls).forEach((key) => {
-            controls[key].updateValueAndValidity();
-        });
     }
 
     /**

--- a/src/app/submission/list/ag-grid/date-filter.component.html
+++ b/src/app/submission/list/ag-grid/date-filter.component.html
@@ -1,0 +1,36 @@
+<div class="form-group">
+    <select class="form-control"
+            (change)="onSelectionChange($event)">
+        <option value="after" [selected]="after">From (inclusive)</option>
+        <option value="before" [selected]="before">To (exclusive)</option>
+        <option value="between" [selected]="between">Range</option>
+    </select>
+</div>
+<div *ngIf="after || between" class="form-group">
+    <label  *ngIf="between" class="control-label" for="date-from">
+        From
+        <span class="text-muted">(including date)</span>
+    </label>
+    <date-input id="date-from"
+                [canUsePastDates]="true"
+                [(ngModel)]="date.from">
+    </date-input>
+</div>
+<div *ngIf="before || between" class="form-group">
+    <label  *ngIf="between" class="control-label" for="date-to">
+        To
+        <span class="text-muted">(excluding date)</span>
+    </label>
+    <date-input id="date-to"
+                [canUsePastDates]="true"
+                [(ngModel)]="date.to">
+    </date-input>
+</div>
+<button class="btn btn-sm btn-primary btn-submit" type="submit"
+        (click)="onApplyClick($event)">
+    Filter
+</button>
+<button class="btn btn-sm btn-default btn-submit" type="button"
+        (click)="onClearClick($event)">
+    Clear
+</button>

--- a/src/app/submission/list/ag-grid/date-filter.component.ts
+++ b/src/app/submission/list/ag-grid/date-filter.component.ts
@@ -63,37 +63,14 @@ class DateRange {
 
 @Component({
     selector: 'ag-date-filter',
-    template: `
-<div style="width:250px">
-    <div style="padding:5px;">
-        <select style="margin: 5px 0" (change)="onSelectionChange($event)">
-            <option value="after" [selected]="after">after</option>
-            <option value="before" [selected]="before">before</option>
-            <option value="between" [selected]="between">between</option>
-        </select>
-        <date-input
-            *ngIf="after || between"
-            [canUsePastDates]="true"
-            [(ngModel)]="date.from">
-        </date-input>
-        <date-input
-            *ngIf="before || between"
-            [(ngModel)]="date.to">
-        </date-input>
-    </div>
-    <div style="padding:0 5px 5px 5px;text-align:right">
-        <button (click)="onApplyClick($event)">apply</button>
-    </div>
-</div>
-    `
+    templateUrl: 'date-filter.component.html'
 })
 export class DateFilterComponent implements AgFilterComponent {
     private params: IFilterParams;
     private valueGetter: (rowNode: RowNode) => any;
-
-    private date: DateRange = new DateRange();
+    private hide: Function;
     private selection: string = 'after';
-
+    private date: DateRange = new DateRange();
     private prev: DateRange;
 
     agInit(params: IFilterParams): void {
@@ -129,6 +106,7 @@ export class DateFilterComponent implements AgFilterComponent {
     }
 
     afterGuiAttached(params: IAfterGuiAttachedParams): void {
+        this.hide = params.hidePopup;
     }
 
     private notifyAboutChanges() {
@@ -136,6 +114,7 @@ export class DateFilterComponent implements AgFilterComponent {
             this.prev = this.date.copy();
             this.params.filterChangedCallback();
         }
+        this.hide();
     }
 
     get after(): boolean {
@@ -161,6 +140,12 @@ export class DateFilterComponent implements AgFilterComponent {
     }
 
     onApplyClick(ev): void {
+        this.notifyAboutChanges();
+    }
+
+    onClearClick(event): void {
+        this.date.to = '';
+        this.date.from = '';
         this.notifyAboutChanges();
     }
 }

--- a/src/app/submission/list/ag-grid/text-filter.component.html
+++ b/src/app/submission/list/ag-grid/text-filter.component.html
@@ -1,0 +1,13 @@
+<div class="form-group">
+    <input class="form-control input-sm"
+           [(ngModel)]="text"
+           #inputEl>
+</div>
+<button class="btn btn-sm btn-primary btn-submit" type="submit"
+        (click)="onApplyClick($event)">
+    Filter
+</button>
+<button class="btn btn-sm btn-default btn-submit" type="button"
+        (click)="onClearClick($event)">
+    Clear
+</button>

--- a/src/app/submission/list/ag-grid/text-filter.component.ts
+++ b/src/app/submission/list/ag-grid/text-filter.component.ts
@@ -1,7 +1,6 @@
 import {
     Component,
-    ViewChild,
-    ViewContainerRef
+    ViewChild
 } from '@angular/core';
 
 import {
@@ -15,16 +14,7 @@ import {AgFilterComponent} from 'ag-grid-angular/main';
 
 @Component({
     selector: 'ag-acc-filter',
-    template: `
-    <div style="padding:5px">
-        <span>Filter:&nbsp;</span>
-        <input #input 
-              [(ngModel)]="text">
-    </div>
-    <div style="padding:0 5px 5px 5px;text-align:right">
-        <button (click)="onApplyClick($event)">apply</button>
-    </div>
-    `
+    templateUrl: 'text-filter.component.html'
 })
 export class TextFilterComponent implements AgFilterComponent {
     private params: IFilterParams;
@@ -32,8 +22,9 @@ export class TextFilterComponent implements AgFilterComponent {
 
     text: string = '';
     private prev: string = '';
+    private hide: Function;
 
-    @ViewChild('input', {read: ViewContainerRef}) public input;
+    @ViewChild('inputEl') public inputEl;
 
     agInit(params: IFilterParams): void {
         this.params = params;
@@ -61,10 +52,16 @@ export class TextFilterComponent implements AgFilterComponent {
     }
 
     afterGuiAttached(params: IAfterGuiAttachedParams): void {
-        this.input.element.nativeElement.focus();
+        this.inputEl.nativeElement.focus();
+        this.hide = params.hidePopup;
     }
 
     onApplyClick(ev): void {
+        this.notifyAboutChanges();
+    }
+
+    onClearClick(event): void {
+        this.text = '';
         this.notifyAboutChanges();
     }
 
@@ -73,5 +70,6 @@ export class TextFilterComponent implements AgFilterComponent {
             this.prev = this.text;
             this.params.filterChangedCallback();
         }
+        this.hide();
     }
 }

--- a/src/app/submission/list/subm-list.component.ts
+++ b/src/app/submission/list/subm-list.component.ts
@@ -143,6 +143,7 @@ export class SubmListComponent {
             paginationPageSize: 15,
             rowHeight: 30,
             localeText: {noRowsToShow: 'No submissions found'},
+            icons: {menu: '<i class="fa fa-filter"/>'},
             getRowNodeId: (item) => {
                 return item.accno;
             },

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -6,6 +6,7 @@ export const DefaultTemplate = {
             'title': 'Describe your study',
             'description': 'Provide any supplementary details of the study that may help discover and/or interpret it',
             'icon': 'fa-tag',
+            'uniqueCols': false,
             'columnTypes': [
                 {
                     'name': 'Organism',
@@ -59,6 +60,7 @@ export const DefaultTemplate = {
                 'description': 'Include the contact details for the authors of the study',
                 'icon': 'fa-vcard',
                 'required': true,
+                'uniqueCols': true,
                 'columnTypes': [
                     {
                         'name': 'Name',
@@ -104,6 +106,7 @@ export const DefaultTemplate = {
                 'title': 'Add Files',
                 'description': 'List the data files for the study and describe their respective scopes',
                 'icon': 'fa-file',
+                'uniqueCols': true,
                 'columnTypes': [
                     {
                         'name': 'Path',
@@ -126,6 +129,7 @@ export const DefaultTemplate = {
                 'title': 'Add Links',
                 'description': 'Provide links to any additional documentation that may be of relevance',
                 'icon': 'fa-link',
+                'uniqueCols': true,
                 'columnTypes': [
                     {
                         'name': 'URL',
@@ -148,6 +152,7 @@ export const DefaultTemplate = {
                 'title': 'Add Publications',
                 'description': 'Add the details of publications relevant or complementary to the study',
                 'icon': 'fa-book',
+                'uniqueCols': true,
                 'columnTypes': [
                     {
                         'name': 'PMID',

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -56,7 +56,7 @@ export const DefaultTemplate = {
             {
                 'name': 'Contact',
                 'title': 'Add Contacts',
-                'description': 'Include contact information for one or more authors of the study',
+                'description': 'Include the contact details for the authors of the study',
                 'icon': 'fa-vcard',
                 'required': true,
                 'columnTypes': [
@@ -66,14 +66,14 @@ export const DefaultTemplate = {
                         'required': true
                     },
                     {
-                        'name': 'Organisation',
+                        'name': 'E-mail',
                         'valueType': 'text',
-                        'values': ['European Bioinformatics Institute', 'Wellcome Sanger Institute', 'Francis Crick Institute', 'MRC Laboratory of Molecular Biology'],
                         'required': true
                     },
                     {
-                        'name': 'E-mail',
+                        'name': 'Organisation',
                         'valueType': 'text',
+                        'values': ['European Bioinformatics Institute', 'Wellcome Sanger Institute', 'Francis Crick Institute', 'MRC Laboratory of Molecular Biology'],
                         'required': true
                     },
                     {

--- a/src/app/submission/shared/hecatos.template.ts
+++ b/src/app/submission/shared/hecatos.template.ts
@@ -1,0 +1,157 @@
+export const DefaultTemplate = {
+    'name': 'DeafultTemplate',
+    'sectionType': {
+        'name': 'Study',
+        'required': true,
+        'annotationsType': {
+            'singleRow': true,
+            'title': 'Describe your study',
+            'description': 'Provide an adequate overview of the Study, make it easier to find and interpret',
+            'columnTypes': [
+                {
+                    'name': 'Factor',
+                    'valueType': 'text'
+                }
+            ]
+        },
+        'fieldTypes': [
+            {
+                'name': 'Title',
+                'valueType': 'text',
+                'required': true,
+                'maxlength': 50
+            },
+            {
+                'name': 'Description',
+                'valueType': 'textblob',
+                'minlength': 50
+            },
+            {
+                'name': 'Design type',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Assay measurement type',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Assay technology type',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Assay technology platform',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Organism',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Organ',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Sample type',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Biological replicate',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Compound',
+                'valueType': 'text'
+            },
+            {
+                'name': 'CHEMBL ID',
+                'valueType': 'text'
+            },
+            {
+                'name': 'StdInChIKey',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Dose',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Protocol Type',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Data type',
+                'valueType': 'text'
+            }
+        ],
+        'featureTypes': [
+            {
+                'name': 'Contact',
+                'title': 'Add Contacts',
+                'description': 'Include contact information for one or more authors of the Study',
+                'required': true,
+                'columnTypes': [
+                    {
+                        'name': 'Name',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
+                        'name': 'Organisation',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
+                        'name': 'E-mail',
+                        'valueType': 'text',
+                        'required': true
+                    },
+                    {
+                        'name': 'Role',
+                        'valueType': 'text'
+                    },
+                    {
+                        'name': 'ORCID',
+                        'valueType': 'text'
+                    },
+                    {
+                        'name': 'Address',
+                        'valueType': 'text'
+                    },
+                    {
+                        'name': 'Department',
+                        'valueType': 'text'
+                    },
+                    {
+                        'name': 'Funding',
+                        'valueType': 'text'
+                    }
+                ]
+            },
+            {
+                'name': 'File',
+                'title': 'Add Files',
+                'description': 'Include Study data, identification, date and time point',
+                'required': true,
+                'columnTypes': [
+                    {
+                        'name': 'Path',
+                        'valueType': 'file',
+                        'required': true
+                    },
+                    {
+                        'name': 'Roche ID',
+                        'valueType': 'text'
+                    },
+                    {
+                        'name': 'Sampling date',
+                        'valueType': 'date'
+                    },
+                    {
+                        'name': 'Sampling time point',
+                        'valueType': 'text'
+                    }
+                ]
+            }
+        ]
+    }
+};

--- a/src/app/submission/shared/pagetab-attributes.utils.ts
+++ b/src/app/submission/shared/pagetab-attributes.utils.ts
@@ -1,5 +1,11 @@
-/* it shifts attributes from submission section to study section */
-export function copyAttributes(obj: any) {
+/**
+ * It shifts attributes from submission section to study section, allowing duplicates if so specified.
+ * NOTE: PageTab allows duplicate attributes and some projects such as HECATOS do take advantage of them.
+ * @param obj - Response object with the submission data
+ * @param {boolean} [isUniqueAttrs = false] - If true, it suffixes duplicate attribute names with a number.
+ * @returns {any} Study section object.
+ */
+export function copyAttributes(obj: any, isUniqueAttrs: boolean = false) {
     if (obj === undefined || obj.attributes === undefined || obj.section === undefined) {
         return obj;
     }
@@ -16,14 +22,24 @@ export function copyAttributes(obj: any) {
                 return rv;
             }, {});
 
-    newObj.section.attributes = Object.keys(attrMap)
-        .map(key => {
-                return attrMap[key].map((v, i) => ({
-                    name: key + (i > 0 ? '' + i : ''),
-                    value: v
-                }));
-            }
-        )
-        .reduce((rv, x) => rv.concat(x, []));
+    newObj.section.attributes = Object.keys(attrMap).map(key => {
+        let mapFn;
+
+        if (isUniqueAttrs) {
+            mapFn = (v, i) => ({
+                name: key + (i > 0 ? '' + i : ''),
+                value: v
+            });
+        } else {
+            mapFn = (v, i) => ({
+                name: key,
+                value: v
+            });
+        }
+
+        return attrMap[key].map(mapFn);
+
+    }).reduce((rv, x) => rv.concat(x, []));
+
     return newObj;
 }

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -63,20 +63,22 @@ export type ValueType = 'text' | 'textblob' | 'date' | 'file';
 export class FieldType extends BaseType {
     readonly required: boolean;
     readonly valueType: ValueType;
+    readonly values: string[];      //suggested values for the field
     readonly minlength: number;
     readonly maxlength: number;
     readonly icon: string;
 
-    constructor(name, obj?: any, scope?: Map<string, any>) {
+    constructor(name, other?: any, scope?: Map<string, any>) {
         super(name, true, scope);
-        obj = obj || {};
-        this.valueType = obj.valueType || 'text';
-        this.minlength = obj.minlength || -1;
-        this.maxlength = obj.maxlength || -1;
+        other = other || {};
+        this.valueType = other.valueType || 'text';
+        this.values = other.values || [];
+        this.minlength = other.minlength || -1;
+        this.maxlength = other.maxlength || -1;
 
         //Sets required to false if not present. If the field has a mininum length, it must be required.
-        if (obj.hasOwnProperty('required')) {
-            this.required = obj.required;
+        if (other.hasOwnProperty('required')) {
+            this.required = other.required;
         } else if (this.minlength > 0) {
             this.required = true;
         } else {
@@ -84,8 +86,8 @@ export class FieldType extends BaseType {
         }
 
         //Normalises the icon for the present type.
-        if (obj.hasOwnProperty('icon')) {
-            this.icon = obj.icon;
+        if (other.hasOwnProperty('icon')) {
+            this.icon = other.icon;
         } else {
             this.icon = 'fa-pencil-square-o';
         }

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -344,6 +344,10 @@ export class Feature extends HasUpdates<UpdateEvent> {
         return this.type.singleRow;
     }
 
+    get uniqueCols(): boolean {
+        return this.type.uniqueCols;
+    }
+
     get typeName(): string {
         return this.type.name;
     }
@@ -463,7 +467,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
      * @param {number} colIndex - Index of the updated column.
      */
     onColumnUpdate(newName: string, colIndex: number) {
-        if (this._columns.allWithName(newName).length == 1) {
+        if (this._columns.allWithName(newName).length == 1 || !this.type.uniqueCols) {
             this._columns.at(colIndex).updateType(this.type.getColumnType(newName));
         }
     }

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -331,7 +331,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
                 this.notify(new UpdateEvent('columns_update', {id: this.id}, event));
 
                 if (event.name == 'column_name_update') {
-                    this.onColumnRename(event.source.value, event.value.index);
+                    this.onColumnUpdate(event.source.value, event.value.index);
                 }
             });
         this._rows.updates()
@@ -457,12 +457,15 @@ export class Feature extends HasUpdates<UpdateEvent> {
     }
 
     /**
-     * Handler for column name updates. It refreshes the type properties of a given column according to name.
+     * Handler for column name updates. It refreshes the type properties of a given column if
+     * the new name is unique.
      * @param {string} newName - Updated column name.
      * @param {number} colIndex - Index of the updated column.
      */
-    onColumnRename(newName: string, colIndex: number) {
-        this._columns.at(colIndex).updateType(this.type.getColumnType(newName));
+    onColumnUpdate(newName: string, colIndex: number) {
+        if (this._columns.allWithName(newName).length == 1) {
+            this._columns.at(colIndex).updateType(this.type.getColumnType(newName));
+        }
     }
 
     addRow(): ValueMap {

--- a/src/app/submission/shared/unique.directive.ts
+++ b/src/app/submission/shared/unique.directive.ts
@@ -46,6 +46,13 @@ export class UniqueValidator implements Validator {
             }
         });
     }
+
+    /**
+     * Updates validity after deletion to avoid inconsistencies.
+     */
+    ngOnDestroy(): void {
+        this.onChange();
+    }
 }
 
 /**

--- a/src/app/submission/shared/unique.directive.ts
+++ b/src/app/submission/shared/unique.directive.ts
@@ -1,5 +1,5 @@
 import {
-    Directive, Injector
+    Directive, Injector, Input
 } from '@angular/core';
 import {
     NG_VALIDATORS,
@@ -21,12 +21,18 @@ import {
 export class UniqueValidator implements Validator {
     validator: ValidatorFn;
 
+    @Input('unique') isUnique: boolean;     //allows the directive to be conditionally applied
+
     constructor(private injector: Injector) {
         this.validator = uniqueValidatorFactory();
     }
 
     validate(formControl: FormControl) {
-        return this.validator(formControl);
+        if (this.isUnique) {
+            return this.validator(formControl);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -299,7 +299,10 @@ input[readonly], textarea[readonly] {
 .bs-datepicker-body table td.disabled span {
   cursor: default;
 }
-
+.bs-datepicker-head button[disabled] {
+  background: transparent !important;
+  color: #979797 !important;
+}
 
 //Restores the border radius applied to right corners on fields inside input-groups
 .input-group .subm-field .form-control {

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -223,10 +223,11 @@ component */
 .validation-pop {
   display: none !important;
   z-index: 950;           //above any dropdowns but below any nav bar
+  font-size: 12px;
   text-align: center;
 }
 .validation-pop .popover-body {
-  padding: 0;
+  padding: .5rem .7rem;
 }
 .has-error .validation-pop {
   display: block !important;
@@ -237,9 +238,7 @@ component */
 @media screen and (min-width: 1360px) {
   .validation-pop {
     min-width: 300px;
-  }
-  .validation-pop .popover-body {
-    padding: .5rem .7rem;
+    font-size: 14px;
   }
 }
 

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -111,16 +111,31 @@
   }
 }
 
-/* Prevents cell menu buttons from being hidden. By default, only shown on hover. */
+/* Prevents cell menu buttons from being hidden. By default, only shown on hover.
+   Additionally, it uses the cell menu's icon to make the two filtering states visually explicit */
 .ag-header-cell-menu-button {
   float: left;
   opacity: 1 !important;
 }
+.ag-fresh .ag-header-cell-menu-button {
+  color: #3c8b9f;
+}
+.ag-header-cell-filtered .ag-header-cell-menu-button {
+  color: #fafafa;
+}
 .ag-header-cell-menu-button, .ag-header-cell-label {
   cursor: pointer;
 }
-.ag-fresh .ag-header-cell-menu-button:hover  {
+.ag-fresh .ag-header-cell-menu-button:hover {
   border-color: #fafafa;
+}
+
+/* Mutes the unsort icon and highlights what the next state is on hover */
+.ag-fresh .ag-sort-none-icon svg {
+  fill: #3c8b9f;
+}
+.ag-header-cell-label:hover polygon:first-child {
+  fill: #fafafa;
 }
 
 /* Permanently hides filter icon */
@@ -154,6 +169,15 @@
 }
 .ag-fresh .ag-ltr .ag-cell-no-focus:last-of-type, .ag-fresh .ag-ltr .ag-header-cell:last-of-type {
   border-right: none;
+}
+
+/* Brings styles of ag-grid's floating menu in line with rest of the app */
+.ag-fresh .ag-menu {
+  padding: 10px;
+  border-color: #d7d7d7;
+}
+.ag-menu .form-group {
+  padding: 0;
 }
 
 //Prevents highlighting of single cells
@@ -194,20 +218,29 @@ component */
   cursor: pointer;
 }
 
-//Makes validation popovers show up only when there is indeed an error.
+//Makes validation popovers show up only when there is indeed an error, preventing it from overflowing its
+//container (eg: scrollable area in feature grids).
 .validation-pop {
-  visibility: hidden;
+  display: none !important;
   z-index: 950;           //above any dropdowns but below any nav bar
-  min-width: 300px;
   text-align: center;
 }
-.has-error .validation-pop {
-  visibility: visible;
+.validation-pop .popover-body {
+  padding: 0;
 }
-
-//Forces muted italics to have a slightly lighter shade
-.text-muted i:not(.fa) {
-  color: #a2a2a2;
+.has-error .validation-pop {
+  display: block !important;
+}
+.has-error .popover-body {
+  color: #bb4a48;
+}
+@media screen and (min-width: 1360px) {
+  .validation-pop {
+    min-width: 300px;
+  }
+  .validation-pop .popover-body {
+    padding: .5rem .7rem;
+  }
 }
 
 //Shades an entire area, preventing any interaction as well.


### PR DESCRIPTION
- Takes advantage of PageTab's specs to allow duplicates, paving the way for compatibility with HeCaToS (factor name annotations). Numerical suffixing of column names together with column uniqueness validation are both optional now. 
- Improves UX for column filters on submission list:
  - Adds a clear button.
  - Closes popup on button press.
  - Uses a sieve icon to convey both the state of filtering and the presence of filtering options.
  - Makes date filter's UI clearer: turns out "From" and "To" dates behave differently.
  - Fixes disabled state for date picker's back button and prevents the click event from bubbling up to the body element (was problematic in combination with ag-Grid's popups).
- Guarantees fitting of popovers within feature widgets by making their styling responsive.
- Generalises logic for typeaheads and makes them behave like suggest boxes.
- Fixes uniqueness validation when deleting fields.


