### PR TITLE
Readonly fields and columns

### DIFF
--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -11,7 +11,7 @@
 
         </div><!--
         --><div *ngFor="let column of columns; let idx = index" class="cell heading-cell column-heading col-xs-3 col-md-2"
-                [ngClass]="{'optional': !column.required && !readonly,
+                [ngClass]="{'optional': !column.required && !column.readonly && !readonly,
                             'has-error': !column.required &&
                                          featureForm.columnControl(column.id).invalid &&
                                          featureForm.columnControl(column.id).touched}">
@@ -24,7 +24,7 @@
                          (remove)="feature.removeColumn(column.id)"
                          [formControl]="featureForm.columnControl(column.id)"
                          [required]="column.required"
-                         [disableEdit]="readonly || !userData.isPrivileged"
+                         [disableEdit]="readonly || column.readonly || !userData.isPrivileged"
                          [disableChange]="column.displayed"
                          [autosuggest]="colNames"
                          [suggestLength]="15"
@@ -51,7 +51,8 @@
             {{rowIdx+1}}
         </div>
         <div class="cell body-cell column-entry col-xs-3 col-md-2" #colEl *ngFor="let column of columns">
-            <div [ngClass]="{'optional': !column.required && !readonly,
+            <div [ngClass]="{'readonly': column.readonly,
+                             'optional': !column.required && !column.readonly && !readonly,
                              'has-error': featureForm.rowValueControl(rowIdx, column.id).invalid &&
                                           featureForm.rowValueControl(rowIdx, column.id).touched}">
                 <subm-field placement="{{first && !last && !column.values.length ? 'bottom' : 'top'}}"
@@ -60,7 +61,7 @@
                             popover="{{featureForm.rowErrors[rowIdx][column.id]}}"
                             [type]="column.valueType"
                             [(ngModel)]="row.valueFor(column.id).value"
-                            [readonly]="readonly"
+                            [readonly]="readonly || column.readonly"
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
                             [autosuggest]="column.values"

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -6,12 +6,13 @@
     <div class="row" #rowEl *ngFor="let column of columns; let idx = index; let first = first; let last = last">
         <div class="cell col-xs-3">
             <div class="form-group key-field"
-                 [ngClass]="{'optional': !column.required && !readonly,
+                 [ngClass]="{'optional': !column.required && !column.readonly && !readonly,
                              'has-error': !column.required &&
                                           featureForm.columnControl(column.id).invalid &&
                                           featureForm.columnControl(column.id).touched}">
-                <div [ngClass]="{'input-group': !readonly && !column.required}">
-                    <span *ngIf="!readonly && !column.required" class="input-group-btn"
+                <div [ngClass]="{'input-group': !readonly && !column.required,
+                                 'readonly': column.readonly}">
+                    <span *ngIf="!readonly && !column.readonly && !column.required" class="input-group-btn"
                           container="body"
                           [tooltip]="feature.canRemoveRowAt(index) ? '' : 'The list must contain one entry at least'">
                           <button type="button" tabindex="-1"
@@ -31,8 +32,8 @@
                            popover="Please use a unique key name"
                            [ngModel]="column.name"
                            [formControl]="featureForm.columnControl(column.id)"
-                           [readonly]="readonly || column.required || column.displayed"
-                           [typeahead]="readonly || column.required || column.displayed ? [] : colNames"
+                           [readonly]="readonly || column.readonly || column.required || column.displayed"
+                           [typeahead]="readonly || column.readonly || column.required || column.displayed ? [] : colNames"
                            [typeaheadMinLength]="0"
                            [typeaheadOptionsLimit]="15"
                            #ahead="bs-typeahead"
@@ -48,7 +49,8 @@
         </div>
         <div class="cell col-xs-9">
             <div class="form-group"
-                 [ngClass]="{'optional': !column.required && !readonly,
+                 [ngClass]="{'readonly': column.readonly,
+                             'optional': !column.required && !column.readonly && !readonly,
                              'has-error': featureForm.rowValueControl(0,column.id).invalid &&
                                           featureForm.rowValueControl(0,column.id).touched}">
                 <subm-field placement="{{first && !last && !column.values.length? 'bottom' : 'top'}}"
@@ -57,7 +59,7 @@
                             popover="{{featureForm.rowErrors[0][column.id]}}"
                             [type]="column.valueType"
                             [(ngModel)]="feature.rows[0].valueFor(column.id).value"
-                            [readonly]="readonly"
+                            [readonly]="readonly || column.readonly"
                             [required]="column.required"
                             [formControl]="featureForm.rowValueControl(0,column.id)"
                             [autosuggest]="column.values"

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.ts
@@ -28,7 +28,7 @@ export class SubmFeatureComponent implements OnInit {
 
     /**
      * Defines the actions of the feature's menu according to its type (list or not). It also gets the type names
-     * of all possible columns just once.
+     * of all readable columns just once.
      */
     ngOnInit() {
         this.actions.push({
@@ -41,7 +41,9 @@ export class SubmFeatureComponent implements OnInit {
                 invoke: () => this.feature.addRow()
             });
         }
-        this.colTypeNames = this.feature.type.columnTypes.map(type => type.name);
+        this.colTypeNames = this.feature.type.columnTypes
+            .filter(type => !type.readonly)
+            .map(type => type.name);
     }
 
     get feature(): Feature {

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -27,13 +27,14 @@
                 </span>
             </label>
             <span *ngIf="!readonly && !field.type.required" class="text-muted pull-right"><i>Optional</i></span>
-            <div [ngClass]="{'input-group': !readonly}">
-                <span *ngIf="!readonly" class="input-group-addon">
+            <div [ngClass]="{'input-group': !readonly && !field.readonly,
+                             'readonly': field.readonly}">
+                <span *ngIf="!readonly && !field.readonly" class="input-group-addon">
                     <i class="fa {{get(field.id, 'icon')}}"></i>
                 </span>
                 <subm-field class="subm-field"
                     [type]="field.valueType"
-                    [readonly]="readonly"
+                    [readonly]="readonly || field.readonly"
                     [required]="field.type.required"
                     [(ngModel)]="field.value"
                     [formControl]="get(field.id)"

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -39,6 +39,11 @@ export const DefaultTemplate = {
                 {
                     'name': 'Cell type',
                     'valueType': 'text'
+                },
+                {
+                    'name': 'AttachTo',
+                    'valueType': 'text',
+                    'readonly': true
                 }
             ]
         },

--- a/src/app/submission/shared/hecatos.template.ts
+++ b/src/app/submission/shared/hecatos.template.ts
@@ -14,6 +14,11 @@ export const HecatosTemplate = {
                     'values': ['Age', 'Compound', 'Dose', 'Dose duration', 'Dose frequency', 'Post treatment duration',
                          'Sampling time point', 'Sampling date', 'Time range', 'Incubation time with respective conc. [uM]'],
                     'displayed': true
+                },
+                {
+                    'name': 'AttachTo',
+                    'valueType': 'text',
+                    'readonly': true
                 }
             ]
         },

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -63,6 +63,7 @@ export type ValueType = 'text' | 'textblob' | 'date' | 'file';
 
 export class FieldType extends BaseType {
     readonly required: boolean;
+    readonly readonly: boolean;
     readonly valueType: ValueType;
     readonly values: string[];      //suggested values for the field
     readonly minlength: number;
@@ -84,6 +85,12 @@ export class FieldType extends BaseType {
             this.required = true;
         } else {
             this.required = false;
+        }
+
+        if (other.hasOwnProperty('readonly')) {
+            this.readonly = other.required;
+        } else {
+            this.readonly = false;
         }
 
         //Normalises the icon for the present type.
@@ -202,6 +209,7 @@ export class AnnotationsType extends FeatureType {
 export class ColumnType extends BaseType {
     readonly required: boolean;     //required data-wise: its fields should have data associated with it to be valid
     readonly displayed: boolean;    //required render-wise: should be visually available regardless of its fields being required or not
+    readonly readonly: boolean;     //renders the column and its member fields as a readonly inputs
     readonly valueType: ValueType;  //type of data for the fields under this column
     readonly values: string[];      //suggested values for the field
 
@@ -215,6 +223,7 @@ export class ColumnType extends BaseType {
         other = other || {};
         this.valueType = other.valueType || 'text';
         this.required = other.required === true;
+        this.readonly = other.readonly === true;
         this.displayed = other.displayed || false;
         this.values = other.values || [];
     }

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -57,15 +57,17 @@ export class Attribute extends HasUpdates<UpdateEvent> {
     readonly id: string;
     required: boolean;
     displayed: boolean;
+    readonly: boolean;
     valueType: ValueType;
     values: string[];
 
     private _name: string;
 
-    constructor(name: string = '', required: boolean = false, displayed: boolean = false, valueType: ValueType = 'text', values: string[] = []) {
+    constructor(name: string = '', required: boolean = false, displayed: boolean = false, readonly: boolean = false, valueType: ValueType = 'text', values: string[] = []) {
         super();
         this.required = required;
         this.displayed = displayed;
+        this.readonly = readonly;
         this.valueType = valueType;
         this.values = values;
         this._name = name;
@@ -315,7 +317,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
         //TODO: Make displayed columns less permanent. Should be added once when the submission is new. Link with "isNew" from submission edit view.
         type.columnTypes.forEach(ct => {
             if (ct.required || ct.displayed) {
-                this.addColumn(ct.name, ct.required, ct.displayed, ct.valueType, ct.values);
+                this.addColumn(ct.name, ct.required, ct.displayed, ct.readonly, ct.valueType, ct.values);
             }
         });
 
@@ -422,7 +424,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
                 const colType = this.type.getColumnType(attrName);
 
                 if (occurAttrs != occurCols) {
-                    this.addColumn(attrName, colType.required, colType.displayed, colType.valueType, colType.values);
+                    this.addColumn(attrName, colType.required, colType.displayed, colType.readonly, colType.valueType, colType.values);
                 }
             });
 
@@ -447,7 +449,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
         });
     }
 
-    addColumn(name?: string, required?: boolean, displayed?: boolean, valueType?: ValueType, values?: string[]): Attribute {
+    addColumn(name?: string, required?: boolean, displayed?: boolean, readonly?: boolean, valueType?: ValueType, values?: string[]): Attribute {
         let defColName = ' ' + (this.colSize() + 1);
         let col;
 
@@ -457,7 +459,7 @@ export class Feature extends HasUpdates<UpdateEvent> {
         } else {
             defColName = 'Column' + defColName;
         }
-        col = new Attribute(name || defColName, required, displayed, valueType, values);
+        col = new Attribute(name || defColName, required, displayed, readonly, valueType, values);
 
         //Updates row and column maps
         this._rows.addKey(col.id);
@@ -666,6 +668,10 @@ export class Field extends HasUpdates<UpdateEvent> {
 
     get valueType(): string {
         return this.type.valueType;
+    }
+
+    get readonly(): string {
+        return this.type.readonly;
     }
 
     get value(): string {


### PR DESCRIPTION
Some attributes and its values need to be readonly, even when showing the edit view. For that purpose, the "readonly" property is introduced in type templates. It makes both columns and fields (be them top-level ones of member of a column's field group) be un-editable.