### PR TITLE
Removable columns

### DIFF
--- a/src/app/shared/inline-edit.component.html
+++ b/src/app/shared/inline-edit.component.html
@@ -22,7 +22,7 @@
                 (click)="startEditing()">
             <i class="fa fa-pencil"></i>
         </button>
-        <button *ngIf="canEdit" class="btn btn-xs btn-link" type="button"
+        <button *ngIf="canEdit && !disableRemove" class="btn btn-xs btn-link" type="button"
                 (click)="onRemoveClick($event)">
             <i class="text-danger fa fa-trash-o"></i>
         </button>

--- a/src/app/shared/inline-edit.component.ts
+++ b/src/app/shared/inline-edit.component.ts
@@ -18,8 +18,9 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 })
 export class InlineEditComponent implements ControlValueAccessor {
     @Input() required?: boolean = false;        //flag indicating if the field must have a value
-    @Input() disableEdit?: boolean = false;     //flag indicating if changing or removing the field is not allowed
+    @Input() disableEdit?: boolean = false;     //flag indicating if changing and removing the field is not allowed
     @Input() disableChange?: boolean = false;   //flag indicating if changing the field's initial value is allowed
+    @Input() disableRemove?: boolean = false;   //flag indicating if removing the field is not allowed
     @Input() emptyValue?: string = '';          //default value for the field if left empty
     @Input() placeholder?: string = '';         //indicative text inside the field if not in focus
     @Input() autosuggest: any[] = [];           //typeahead list of suggested values

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -11,7 +11,7 @@
 
         </div><!--
         --><div *ngFor="let column of columns; let idx = index" class="cell heading-cell column-heading col-xs-3 col-md-2"
-                [ngClass]="{'optional': !column.required && !column.readonly && !readonly,
+                [ngClass]="{'optional': column.removable && !isColUIReq(column),
                             'has-error': !column.required &&
                                          featureForm.columnControl(column.id).invalid &&
                                          featureForm.columnControl(column.id).touched}">
@@ -26,6 +26,7 @@
                          [required]="column.required"
                          [disableEdit]="readonly || column.readonly || !userData.isPrivileged"
                          [disableChange]="column.displayed"
+                         [disableRemove]="!column.removable"
                          [autosuggest]="colNames"
                          [suggestLength]="15"
                          [unique]="feature.uniqueCols"
@@ -52,7 +53,7 @@
         </div>
         <div class="cell body-cell column-entry col-xs-3 col-md-2" #colEl *ngFor="let column of columns">
             <div [ngClass]="{'readonly': column.readonly,
-                             'optional': !column.required && !column.readonly && !readonly,
+                             'optional': !isColUIReq(column),
                              'has-error': featureForm.rowValueControl(rowIdx, column.id).invalid &&
                                           featureForm.rowValueControl(rowIdx, column.id).touched}">
                 <subm-field placement="{{first && !last && !column.values.length ? 'bottom' : 'top'}}"

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -18,8 +18,8 @@ import {TypeaheadDirective} from "ngx-bootstrap";
     styleUrls: ['./feature-grid.component.css']
 })
 export class FeatureGridComponent implements AfterViewInit {
-    @Input() featureForm: FeatureForm;
-    @Input() readonly? = false;
+    @Input() featureForm: FeatureForm;      //Reactive data structure for the form containing this feature
+    @Input() readonly? = false;             //Flag for features that cannot be edited (e.g. sent state for submissions)
     @Input() colNames: string[] = [];       //List of allowed column names out of the list specified in the default template
     @ViewChildren('ahead') typeaheads: QueryList<TypeaheadDirective>;
     @ViewChildren('rowEl') rowEls: QueryList<ElementRef>;
@@ -105,5 +105,15 @@ export class FeatureGridComponent implements AfterViewInit {
         //Updates the row and notifies the outside world as a single change event.
         this.feature.add(attributes, rowIdx);
         this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
+    }
+
+    /**
+     * Tests if a given column is required in terms of the UI. For example, a column may not be required
+     * validation-wise but may still have to be rendered with the same styling applied to required fields.
+     * @param {Attribute} attr - Attribute object corresponding to the column to be rendered.
+     * @returns {boolean} True if the column has to be rendered as required.
+     */
+    isColUIReq(attr: Attribute) {
+        return this.readonly || attr.readonly || attr.required;
     }
 }

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -6,13 +6,12 @@
     <div class="row" #rowEl *ngFor="let column of columns; let idx = index; let first = first; let last = last">
         <div class="cell col-xs-3">
             <div class="form-group key-field"
-                 [ngClass]="{'optional': !column.required && !column.readonly && !readonly,
+                 [ngClass]="{'optional': column.removable && !isColUIReq(column),
                              'has-error': !column.required &&
                                           featureForm.columnControl(column.id).invalid &&
                                           featureForm.columnControl(column.id).touched}">
-                <div [ngClass]="{'input-group': !readonly && !column.required,
-                                 'readonly': column.readonly}">
-                    <span *ngIf="!readonly && !column.readonly && !column.required" class="input-group-btn"
+                <div [ngClass]="{'input-group': column.removable && !isColUIReq(column), 'readonly': column.readonly}">
+                    <span *ngIf="column.removable && !isColUIReq(column)" class="input-group-btn"
                           container="body"
                           [tooltip]="feature.canRemoveRowAt(index) ? '' : 'The list must contain one entry at least'">
                           <button type="button" tabindex="-1"
@@ -32,8 +31,8 @@
                            popover="Please use a unique key name"
                            [ngModel]="column.name"
                            [formControl]="featureForm.columnControl(column.id)"
-                           [readonly]="readonly || column.readonly || column.required || column.displayed"
-                           [typeahead]="readonly || column.readonly || column.required || column.displayed ? [] : colNames"
+                           [readonly]="isColUIReq(column) || column.displayed"
+                           [typeahead]="isColUIReq(column) || column.displayed ? [] : colNames"
                            [typeaheadMinLength]="0"
                            [typeaheadOptionsLimit]="15"
                            #ahead="bs-typeahead"
@@ -50,7 +49,7 @@
         <div class="cell col-xs-9">
             <div class="form-group"
                  [ngClass]="{'readonly': column.readonly,
-                             'optional': !column.required && !column.readonly && !readonly,
+                             'optional': !isColUIReq(column),
                              'has-error': featureForm.rowValueControl(0,column.id).invalid &&
                                           featureForm.rowValueControl(0,column.id).touched}">
                 <subm-field placement="{{first && !last && !column.values.length? 'bottom' : 'top'}}"

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.ts
@@ -58,4 +58,14 @@ export class FeatureListComponent implements AfterViewInit {
             this.onColumnChange(column, selection.value);
         }
     }
+
+    /**
+     * Tests if a given column is required in terms of the UI. For example, a column may not be required
+     * validation-wise but may still have to be rendered with the same styling applied to required fields.
+     * @param {Attribute} attr - Attribute object corresponding to the column to be rendered.
+     * @returns {boolean} True if the column has to be rendered as required.
+     */
+    isColUIReq(attr: Attribute) {
+        return this.readonly || attr.readonly || attr.required;
+    }
 }

--- a/src/app/submission/list/subm-add.component.html
+++ b/src/app/submission/list/subm-add.component.html
@@ -1,7 +1,7 @@
 <div bsModal class="modal fade" role="dialog" aria-hidden="true"
      #bsModal="bs-modal"
      (onShown)="onShown(focusBtn)">
-    <div class="modal-dialog modal-sm">
+    <div class="modal-dialog">
         <div class="modal-content">
             <form novalidate autocomplete="off"
                   #form="ngForm"
@@ -13,8 +13,8 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    Please select a project from the list below. Leave the default option if the new submission is
-                    a standalone study or its project is not in the list.
+                    To create a blank submission, please select a project from the list below. You may leave the default
+                    option if the new submission is a stand-alone study or its parent project is not in the list.
                     <div class="form-group">
                         <label class="control-label">What is the study's parent project?</label>
                         <div *ngFor="let name of projectNames" class="radio">

--- a/src/app/submission/list/subm-list.component.ts
+++ b/src/app/submission/list/subm-list.component.ts
@@ -75,7 +75,7 @@ export class ActionButtonsCellComponent implements AgRendererComponent {
 
 @Component({
     selector: 'date-cell',
-    template: `{{value | date: appConfig.dateListFormat}}`
+    template: `{{!value ? '&mdash;' : value | date: appConfig.dateListFormat}}`
 })
 export class DateCellComponent implements AgRendererComponent {
     value: Date;

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -1,5 +1,6 @@
 export const DefaultTemplate = {
     'name': 'Default',
+    'description': 'Generic submission for stand-alone or unsupported studies',
     'sectionType': {
         'name': 'Study',
         'annotationsType': {
@@ -10,19 +11,62 @@ export const DefaultTemplate = {
                 {
                     'name': 'Organism',
                     'valueType': 'text',
-                    'values': ['Homo sapiens', 'Mus musculus', 'Arabidopsis thaliana', 'Rattus norvegicus',
-                        'Drosophila melanogaster', 'Oryza sativa Japonica Group', 'Anas platyrhyncho',
-                        'Anolis carolinensis', 'Anopheles gambiae', 'Arabidopsis lyrata', 'Aspergillus fumigatus',
-                        'Bos Taurus', 'Brachypodium distachyon', 'Brassica oleracea', 'Brassica rapa',
-                        'Caenorhabditis elegans', 'Canis familiaris', 'Chlorocebus sabaeus', 'Ciona intestinalis',
-                        'Ciona savignyi', 'Danio rerio', 'Dasypus novemcinctus', 'Equus caballus', 'Gallus gallus',
-                        'Glycine max', 'Gorilla gorilla', 'Hordeum vulgare', 'Macaca mulatta', 'Medicago truncatula',
-                        'Monodelphis domestica', 'Musa acuminate', 'Ornithorhynchus anatinus', 'Oryctolagus cuniculus',
-                        'Oryza rufipogon', 'Ovis aries', 'Pan troglodytes', 'Papio Anubis',  'Physcomitrella patens',
-                        'Pongo abelii', 'Populus trichocarpa', 'Saccharomyces cerevisiae', 'Schistosoma mansoni',
-                        'Schizosaccharomyces pombe', 'Solanum lycopersicum', 'Solanum tuberosum', 'Sorghum bicolor',
-                        'Sus scrofa', 'Tetraodon nigroviridis', 'Theobroma cacao', 'Triticum aestivum', 'Vitis vinifera',
-                        'Xenopus tropicalis', 'Yarrowia lipolytica', 'Zea mays']
+                    'values': [
+                        'Homo sapiens',
+                        'Mus musculus',
+                        'Arabidopsis thaliana',
+                        'Rattus norvegicus',
+                        'Drosophila melanogaster',
+                        'Oryza sativa Japonica Group',
+                        'Anas platyrhyncho',
+                        'Anolis carolinensis',
+                        'Anopheles gambiae',
+                        'Arabidopsis lyrata',
+                        'Aspergillus fumigatus',
+                        'Bos Taurus',
+                        'Brachypodium distachyon',
+                        'Brassica oleracea',
+                        'Brassica rapa',
+                        'Caenorhabditis elegans',
+                        'Canis familiaris',
+                        'Chlorocebus sabaeus',
+                        'Ciona intestinalis',
+                        'Ciona savignyi',
+                        'Danio rerio',
+                        'Dasypus novemcinctus',
+                        'Equus caballus',
+                        'Gallus gallus',
+                        'Glycine max',
+                        'Gorilla gorilla',
+                        'Hordeum vulgare',
+                        'Macaca mulatta',
+                        'Medicago truncatula',
+                        'Monodelphis domestica',
+                        'Musa acuminate',
+                        'Ornithorhynchus anatinus',
+                        'Oryctolagus cuniculus',
+                        'Oryza rufipogon',
+                        'Ovis aries',
+                        'Pan troglodytes',
+                        'Papio Anubis',
+                        'Physcomitrella patens',
+                        'Pongo abelii',
+                        'Populus trichocarpa',
+                        'Saccharomyces cerevisiae',
+                        'Schistosoma mansoni',
+                        'Schizosaccharomyces pombe',
+                        'Solanum lycopersicum',
+                        'Solanum tuberosum',
+                        'Sorghum bicolor',
+                        'Sus scrofa',
+                        'Tetraodon nigroviridis',
+                        'Theobroma cacao',
+                        'Triticum aestivum',
+                        'Vitis vinifera',
+                        'Xenopus tropicalis',
+                        'Yarrowia lipolytica',
+                        'Zea mays'
+                    ]
                 },
                 {
                     'name': 'Experimental design',
@@ -146,7 +190,8 @@ export const DefaultTemplate = {
                     {
                         'name': 'ORCID',
                         'valueType': 'orcid',
-                        'displayed': true
+                        'displayed': true,
+                        'removable': false
                     },
                     {
                         'name': 'Address',
@@ -218,7 +263,8 @@ export const DefaultTemplate = {
                     {
                         'name': 'PMID',
                         'valueType': 'pubmedid',
-                        'displayed': true
+                        'displayed': true,
+                        'removable': false
                     },
                     {
                         'name': 'Authors',

--- a/src/app/submission/shared/hecatos.template.ts
+++ b/src/app/submission/shared/hecatos.template.ts
@@ -1,5 +1,6 @@
 export const HecatosTemplate = {
     'name': 'HeCaToS',
+    'description': 'Hepatic and Cardiac Toxicity Systems modelling',
     'sectionType': {
         'name': 'Study',
         'required': true,
@@ -11,8 +12,18 @@ export const HecatosTemplate = {
                 {
                     'name': 'Factor',
                     'valueType': 'text',
-                    'values': ['Age', 'Compound', 'Dose', 'Dose duration', 'Dose frequency', 'Post treatment duration',
-                         'Sampling time point', 'Sampling date', 'Time range', 'Incubation time with respective conc. [uM]'],
+                    'values': [
+                        'Age',
+                        'Compound',
+                        'Dose',
+                        'Dose duration',
+                        'Dose frequency',
+                        'Post treatment duration',
+                        'Sampling time point',
+                        'Sampling date',
+                        'Time range',
+                        'Incubation time with respective conc. [uM]'
+                    ],
                     'displayed': true
                 },
                 {
@@ -56,19 +67,62 @@ export const HecatosTemplate = {
             {
                 'name': 'Organism',
                 'valueType': 'text',
-                'values': ['Homo sapiens', 'Mus musculus', 'Arabidopsis thaliana', 'Rattus norvegicus',
-                    'Drosophila melanogaster', 'Oryza sativa Japonica Group', 'Anas platyrhyncho',
-                    'Anolis carolinensis', 'Anopheles gambiae', 'Arabidopsis lyrata', 'Aspergillus fumigatus',
-                    'Bos Taurus', 'Brachypodium distachyon', 'Brassica oleracea', 'Brassica rapa',
-                    'Caenorhabditis elegans', 'Canis familiaris', 'Chlorocebus sabaeus', 'Ciona intestinalis',
-                    'Ciona savignyi', 'Danio rerio', 'Dasypus novemcinctus', 'Equus caballus', 'Gallus gallus',
-                    'Glycine max', 'Gorilla gorilla', 'Hordeum vulgare', 'Macaca mulatta', 'Medicago truncatula',
-                    'Monodelphis domestica', 'Musa acuminate', 'Ornithorhynchus anatinus', 'Oryctolagus cuniculus',
-                    'Oryza rufipogon', 'Ovis aries', 'Pan troglodytes', 'Papio Anubis',  'Physcomitrella patens',
-                    'Pongo abelii', 'Populus trichocarpa', 'Saccharomyces cerevisiae', 'Schistosoma mansoni',
-                    'Schizosaccharomyces pombe', 'Solanum lycopersicum', 'Solanum tuberosum', 'Sorghum bicolor',
-                    'Sus scrofa', 'Tetraodon nigroviridis', 'Theobroma cacao', 'Triticum aestivum', 'Vitis vinifera',
-                    'Xenopus tropicalis', 'Yarrowia lipolytica', 'Zea mays']
+                'values': [
+                    'Homo sapiens',
+                    'Mus musculus',
+                    'Arabidopsis thaliana',
+                    'Rattus norvegicus',
+                    'Drosophila melanogaster',
+                    'Oryza sativa Japonica Group',
+                    'Anas platyrhyncho',
+                    'Anolis carolinensis',
+                    'Anopheles gambiae',
+                    'Arabidopsis lyrata',
+                    'Aspergillus fumigatus',
+                    'Bos Taurus',
+                    'Brachypodium distachyon',
+                    'Brassica oleracea',
+                    'Brassica rapa',
+                    'Caenorhabditis elegans',
+                    'Canis familiaris',
+                    'Chlorocebus sabaeus',
+                    'Ciona intestinalis',
+                    'Ciona savignyi',
+                    'Danio rerio',
+                    'Dasypus novemcinctus',
+                    'Equus caballus',
+                    'Gallus gallus',
+                    'Glycine max',
+                    'Gorilla gorilla',
+                    'Hordeum vulgare',
+                    'Macaca mulatta',
+                    'Medicago truncatula',
+                    'Monodelphis domestica',
+                    'Musa acuminate',
+                    'Ornithorhynchus anatinus',
+                    'Oryctolagus cuniculus',
+                    'Oryza rufipogon',
+                    'Ovis aries',
+                    'Pan troglodytes',
+                    'Papio Anubis',
+                    'Physcomitrella patens',
+                    'Pongo abelii',
+                    'Populus trichocarpa',
+                    'Saccharomyces cerevisiae',
+                    'Schistosoma mansoni',
+                    'Schizosaccharomyces pombe',
+                    'Solanum lycopersicum',
+                    'Solanum tuberosum',
+                    'Sorghum bicolor',
+                    'Sus scrofa',
+                    'Tetraodon nigroviridis',
+                    'Theobroma cacao',
+                    'Triticum aestivum',
+                    'Vitis vinifera',
+                    'Xenopus tropicalis',
+                    'Yarrowia lipolytica',
+                    'Zea mays'
+                ]
             },
             {
                 'name': 'Organ',
@@ -162,7 +216,8 @@ export const HecatosTemplate = {
                     },
                     {
                         'name': 'Address',
-                        'valueType': 'text'
+                        'valueType': 'text',
+                        'removable': false
                     },
                     {
                         'name': 'Department',
@@ -236,7 +291,8 @@ export const HecatosTemplate = {
                     {
                         'name': 'PMID',
                         'valueType': 'pubmedid',
-                        'displayed': true
+                        'displayed': true,
+                        'removable': false
                     },
                     {
                         'name': 'Authors',

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -88,7 +88,7 @@ export class FieldType extends BaseType {
         }
 
         if (other.hasOwnProperty('readonly')) {
-            this.readonly = other.required;
+            this.readonly = other.readonly;
         } else {
             this.readonly = false;
         }
@@ -208,8 +208,12 @@ export class AnnotationsType extends FeatureType {
 
 export class ColumnType extends BaseType {
     readonly required: boolean;     //required data-wise: its fields should have data associated with it to be valid
+                                    //NOTE: A required column's name cannot be changed.
     readonly displayed: boolean;    //required render-wise: should be visually available regardless of its fields being required or not
+                                    //NOTE: This guaranteed rendering implies that the column's name cannot be changed.
     readonly readonly: boolean;     //renders the column and its member fields as a readonly inputs
+                                    //NOTE: Notice that BOTH the column field and member fields will be readonly.
+    readonly removable: boolean;    //renders the column without removal controls (useful for un-required yet un-removable columns).
     readonly valueType: ValueType;  //type of data for the fields under this column
     readonly values: string[];      //suggested values for the field
 
@@ -226,6 +230,13 @@ export class ColumnType extends BaseType {
         this.readonly = other.readonly === true;
         this.displayed = other.displayed || false;
         this.values = other.values || [];
+
+        //All columns are removable unless stated otherwise.
+        if (other.hasOwnProperty('removable')) {
+            this.removable = other.removable;
+        } else {
+            this.removable = true;
+        }
     }
 }
 


### PR DESCRIPTION
Adds a "removable" column property to type templates. It caters for cases whereby the column may not be required or, while its name can be changed, the column itself may not be removed. For example, the PubMed ID column: it's not required but it should be displayed and may not be removed.