### PR TITLE
Prevents the rendering of empty rows or wholly empty features

### DIFF
--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -257,6 +257,8 @@ export class SubmEditComponent implements OnInit, OnDestroy {
     }
 
     onSubmit(event) {
+        let wrappedSubm;
+
         //TODO: Why is this needed?
         if (event) {
             event.preventDefault();
@@ -277,7 +279,8 @@ export class SubmEditComponent implements OnInit, OnDestroy {
         }
 
         //TODO: this could probably do with its own method
-        this.submService.submitSubmission(this.wrap(true)).subscribe(
+        wrappedSubm = this.wrap(true);
+        this.submService.submitSubmission(wrappedSubm).subscribe(
             resp => {
 
                 //Updates the acccession number of a temporary submission with the one assigned by the server.

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -34,46 +34,47 @@
             </inline-edit>
         </div>
     </div>
-    <div class="row" #rowEl
-         *ngFor="let row of rows; let rowIdx = index; let first = first; let last = last">
-        <div class="cell heading-cell row-heading col-xs-1 col-md-1 text-center">
-            <span container="body"
-                  [tooltip]="feature.canRemoveRowAt(index) ? '' : 'The table must contain one row at least'">
-                <button class="btn btn-danger btn-sm" type="button"
-                        [ngClass]="{'invisible': readonly}"
-                        [disabled]="!feature.canRemoveRowAt(index)"
-                        (click)="feature.removeRowAt(rowIdx)"
-                        [tooltip]="'Delete ' + feature.typeName.toLowerCase() + ' ' + (rowIdx + 1)"
-                        placement="bottom"
-                        container="body">
-                    <i class="fa fa-trash"></i>
-                </button>
-            </span>
-            {{rowIdx+1}}
-        </div>
-        <div class="cell body-cell column-entry col-xs-3 col-md-2" #colEl *ngFor="let column of columns">
-            <div [ngClass]="{'readonly': column.readonly,
-                             'optional': !isColUIReq(column),
-                             'has-warning': !featureForm.feature.type.required &&
-                                            featureForm.rowValueControl(rowIdx, column.id).invalid &&
-                                            featureForm.rowValueControl(rowIdx, column.id).touched,
-                             'has-error': featureForm.feature.type.required &&
-                                          featureForm.rowValueControl(rowIdx, column.id).invalid &&
-                                          featureForm.rowValueControl(rowIdx, column.id).touched}">
-                <subm-field placement="{{first && !last && !column.values.length ? 'bottom' : 'top'}}"
-                            triggers="focus"
-                            containerClass="validation-pop text-danger"
-                            popover="{{featureForm.rowErrors[rowIdx][column.id]}}"
-                            [type]="column.valueType"
-                            [(ngModel)]="row.valueFor(column.id).value"
-                            [readonly]="readonly || column.readonly"
-                            [required]="column.required"
-                            [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
-                            [autosuggest]="column.values"
-                            [suggestLength]="15"
-                            (async)="addOnAsync($event, rowIdx)"
-                            validate-onblur>
-                </subm-field>
+    <div *ngFor="let row of rows; let rowIdx = index; let first = first; let last = last">
+        <div *ngIf="!readonly || !row.isEmpty" class="row" #rowEl>
+            <div class="cell heading-cell row-heading col-xs-1 col-md-1 text-center">
+                <span container="body"
+                      [tooltip]="feature.canRemoveRowAt(index) ? '' : 'The table must contain one row at least'">
+                    <button class="btn btn-danger btn-sm" type="button"
+                            [ngClass]="{'invisible': readonly}"
+                            [disabled]="!feature.canRemoveRowAt(index)"
+                            (click)="feature.removeRowAt(rowIdx)"
+                            [tooltip]="'Delete ' + feature.typeName.toLowerCase() + ' ' + (rowIdx + 1)"
+                            placement="bottom"
+                            container="body">
+                        <i class="fa fa-trash"></i>
+                    </button>
+                </span>
+                {{rowIdx+1}}
+            </div>
+            <div class="cell body-cell column-entry col-xs-3 col-md-2" #colEl *ngFor="let column of columns">
+                <div [ngClass]="{'readonly': column.readonly,
+                                 'optional': !isColUIReq(column),
+                                 'has-warning': !featureForm.feature.type.required &&
+                                                featureForm.rowValueControl(rowIdx, column.id).invalid &&
+                                                featureForm.rowValueControl(rowIdx, column.id).touched,
+                                 'has-error': featureForm.feature.type.required &&
+                                              featureForm.rowValueControl(rowIdx, column.id).invalid &&
+                                              featureForm.rowValueControl(rowIdx, column.id).touched}">
+                    <subm-field placement="{{first && !last && !column.values.length ? 'bottom' : 'top'}}"
+                                triggers="focus"
+                                containerClass="validation-pop text-danger"
+                                popover="{{featureForm.rowErrors[rowIdx][column.id]}}"
+                                [type]="column.valueType"
+                                [(ngModel)]="row.valueFor(column.id).value"
+                                [readonly]="readonly || column.readonly"
+                                [required]="column.required"
+                                [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
+                                [autosuggest]="column.values"
+                                [suggestLength]="15"
+                                (async)="addOnAsync($event, rowIdx)"
+                                validate-onblur>
+                    </subm-field>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -3,72 +3,74 @@
         <div class="cell heading col-xs-3">Key</div>
         <div class="cell heading col-xs-9">Value</div>
     </div>
-    <div class="row" #rowEl *ngFor="let column of columns; let idx = index; let first = first; let last = last">
-        <div class="cell col-xs-3">
-            <div class="form-group key-field"
-                 [ngClass]="{'optional': column.removable && !isColUIReq(column),
-                             'has-error': !column.required &&
-                                          featureForm.columnControl(column.id).invalid &&
-                                          featureForm.columnControl(column.id).touched}">
-                <div [ngClass]="{'input-group': column.removable && !isColUIReq(column), 'readonly': column.readonly}">
-                    <span *ngIf="column.removable && !isColUIReq(column)" class="input-group-btn"
-                          container="body"
-                          [tooltip]="feature.canRemoveRowAt(index) ? '' : 'The list must contain one entry at least'">
-                          <button type="button" tabindex="-1"
-                                  class="btn btn-sm btn-danger btn-flat"
-                                  (click)="feature.removeRowAt(idx)"
-                                  [disabled]="!feature.canRemoveRowAt(idx)"
-                                  [tooltip]="'Delete &quot;' + column.name + '&quot; entry'"
-                                  placement="bottom"
-                                  container="body">
-                               <i class="fa fa-trash-o"></i>
-                          </button>
-                    </span>
-                    <input type="text" class="form-control input-sm"
-                           placement="{{first && !last && !colNames.length? 'bottom' : 'top'}}"
-                           triggers="focus"
-                           containerClass="validation-pop text-danger"
-                           popover="Please use a unique key name"
-                           [ngModel]="column.name"
-                           [formControl]="featureForm.columnControl(column.id)"
-                           [readonly]="isColUIReq(column) || column.displayed"
-                           [typeahead]="isColUIReq(column) || column.displayed ? [] : colNames"
-                           [typeaheadMinLength]="0"
-                           [typeaheadOptionsLimit]="15"
-                           #ahead="bs-typeahead"
-                           [unique]="feature.uniqueCols"
-                           validate-onblur
-                           (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
-                           (change)="onColumnChange(column, $event.target.value)"
-                           (typeaheadOnSelect)="onSuggestSelect($event, column)"
-                           (blur)="featureForm.columnControl(column.id).value ||
-                                   featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
+    <div *ngFor="let column of columns; let idx = index; let first = first; let last = last">
+        <div class="row" #rowEl *ngIf="!readonly || feature.rows[0].valueFor(column.id).value.length">
+            <div class="cell col-xs-3">
+                <div class="form-group key-field"
+                     [ngClass]="{'optional': column.removable && !isColUIReq(column),
+                                 'has-error': !column.required &&
+                                              featureForm.columnControl(column.id).invalid &&
+                                              featureForm.columnControl(column.id).touched}">
+                    <div [ngClass]="{'input-group': column.removable && !isColUIReq(column), 'readonly': column.readonly}">
+                        <span *ngIf="column.removable && !isColUIReq(column)" class="input-group-btn"
+                              container="body"
+                              [tooltip]="feature.canRemoveRowAt(index) ? '' : 'The list must contain one entry at least'">
+                              <button type="button" tabindex="-1"
+                                      class="btn btn-sm btn-danger btn-flat"
+                                      (click)="feature.removeRowAt(idx)"
+                                      [disabled]="!feature.canRemoveRowAt(idx)"
+                                      [tooltip]="'Delete &quot;' + column.name + '&quot; entry'"
+                                      placement="bottom"
+                                      container="body">
+                                   <i class="fa fa-trash-o"></i>
+                              </button>
+                        </span>
+                        <input type="text" class="form-control input-sm"
+                               placement="{{first && !last && !colNames.length? 'bottom' : 'top'}}"
+                               triggers="focus"
+                               containerClass="validation-pop text-danger"
+                               popover="Please use a unique key name"
+                               [ngModel]="column.name"
+                               [formControl]="featureForm.columnControl(column.id)"
+                               [readonly]="isColUIReq(column) || column.displayed"
+                               [typeahead]="isColUIReq(column) || column.displayed ? [] : colNames"
+                               [typeaheadMinLength]="0"
+                               [typeaheadOptionsLimit]="15"
+                               #ahead="bs-typeahead"
+                               [unique]="feature.uniqueCols"
+                               validate-onblur
+                               (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
+                               (change)="onColumnChange(column, $event.target.value)"
+                               (typeaheadOnSelect)="onSuggestSelect($event, column)"
+                               (blur)="featureForm.columnControl(column.id).value ||
+                                       featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="cell col-xs-9">
-            <div class="form-group"
-                 [ngClass]="{'readonly': column.readonly,
-                             'optional': !isColUIReq(column),
-                             'has-warning': !featureForm.feature.type.required &&
-                                            featureForm.rowValueControl(0,column.id).invalid &&
-                                            featureForm.rowValueControl(0,column.id).touched,
-                             'has-error': featureForm.feature.type.required &&
-                                          featureForm.rowValueControl(0,column.id).invalid &&
-                                          featureForm.rowValueControl(0,column.id).touched}">
-                <subm-field placement="{{first && !last && !column.values.length? 'bottom' : 'top'}}"
-                            triggers="focus"
-                            containerClass="validation-pop text-danger"
-                            popover="{{featureForm.rowErrors[0][column.id]}}"
-                            [type]="column.valueType"
-                            [(ngModel)]="feature.rows[0].valueFor(column.id).value"
-                            [readonly]="readonly || column.readonly"
-                            [required]="column.required"
-                            [formControl]="featureForm.rowValueControl(0,column.id)"
-                            [autosuggest]="column.values"
-                            [suggestLength]="15"
-                            validate-onblur>
-                </subm-field>
+            <div class="cell col-xs-9">
+                <div class="form-group"
+                     [ngClass]="{'readonly': column.readonly,
+                                 'optional': !isColUIReq(column),
+                                 'has-warning': !featureForm.feature.type.required &&
+                                                featureForm.rowValueControl(0,column.id).invalid &&
+                                                featureForm.rowValueControl(0,column.id).touched,
+                                 'has-error': featureForm.feature.type.required &&
+                                              featureForm.rowValueControl(0,column.id).invalid &&
+                                              featureForm.rowValueControl(0,column.id).touched}">
+                    <subm-field placement="{{first && !last && !column.values.length? 'bottom' : 'top'}}"
+                                triggers="focus"
+                                containerClass="validation-pop text-danger"
+                                popover="{{featureForm.rowErrors[0][column.id]}}"
+                                [type]="column.valueType"
+                                [(ngModel)]="feature.rows[0].valueFor(column.id).value"
+                                [readonly]="readonly || column.readonly"
+                                [required]="column.required"
+                                [formControl]="featureForm.rowValueControl(0,column.id)"
+                                [autosuggest]="column.values"
+                                [suggestLength]="15"
+                                validate-onblur>
+                    </subm-field>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/submission/edit/subm-form/feature/subm-feature.component.html
+++ b/src/app/submission/edit/subm-form/feature/subm-feature.component.html
@@ -23,15 +23,20 @@
     </div>
 
     <div class="panel-body" #featureEl>
-        <subm-feature-grid *ngIf="!feature.singleRow"
-                           [featureForm]="featureForm"
-                           [colNames]="allowedCols"
-                           [readonly]="readonly">
-        </subm-feature-grid>
-        <subm-feature-list *ngIf="feature.singleRow"
-                           [featureForm]="featureForm"
-                           [colNames]="allowedCols"
-                           [readonly]="readonly">
-        </subm-feature-list>
+        <div *ngIf="!readonly || !feature.isEmpty()">
+            <subm-feature-grid *ngIf="!feature.singleRow"
+                               [featureForm]="featureForm"
+                               [colNames]="allowedCols"
+                               [readonly]="readonly">
+            </subm-feature-grid>
+            <subm-feature-list *ngIf="feature.singleRow"
+                               [featureForm]="featureForm"
+                               [colNames]="allowedCols"
+                               [readonly]="readonly">
+            </subm-feature-list>
+        </div>
+        <div *ngIf="readonly && feature.isEmpty()">
+            No data provided
+        </div>
     </div>
 </div>

--- a/src/app/submission/shared/pagetab.model.ts
+++ b/src/app/submission/shared/pagetab.model.ts
@@ -128,10 +128,10 @@ export class PageTab implements SubmissionData {
         };
 
         page.section = PageTab.fromSection(subm.root);
-        if (isSanitise) { console.log(page);
+        if (isSanitise) {
             removeBlankAttrs(page.section);
         }
-        console.log(page);
+
         //As per requirements of pagetab's current implementation, some attributes must not be within the section.
         //NOTE: AttacthTo, ReleaseDate and Title are special attributes that pertain the whole submission.
         page['attributes'] = [];

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -131,6 +131,19 @@ export class ValueMap extends HasUpdates<UpdateEvent> {
         (keys || []).forEach(key => this.add(key));
     }
 
+    /**
+     * Determines if the values making this map up are all empty strings.
+     * @returns {boolean} True if the map has no non-empty value.
+     */
+    get isEmpty(): boolean {
+        let valuesLength = 0;
+
+        this.valueMap.forEach(valueObj => {
+            valuesLength = valuesLength + valueObj.value.length;
+        });
+        return valuesLength == 0;
+    }
+
     valueFor(key: string): AttributeValue {
         return this.valueMap.get(key);
     }
@@ -395,6 +408,16 @@ export class Feature extends HasUpdates<UpdateEvent> {
 
     size(): number {
         return this.singleRow ? this.colSize() : this.rowSize();
+    }
+
+    /**
+     * Determines the feature is made up of empty rows.
+     * NOTE: This is equally applicable to lists as long as they are considered transposed grids, the
+     * only row being the set of values for each key.
+     * @returns {boolean} True if all rows are empty.
+     */
+    isEmpty(): boolean {
+        return this.rows.every(row => row.isEmpty);
     }
 
     /**


### PR DESCRIPTION
When showing the results of a submission, optional features with whole rows empty are rendered without filtering out said rows. Now, every time a whole feature or a row is rendered on read-only mode (the one employed in the submission results view), it is tested for emptiness at the ValueMap level.