### PR TITLE
ACL-filtered template selection

### DIFF
--- a/src/app/auth/user-data.ts
+++ b/src/app/auth/user-data.ts
@@ -105,7 +105,40 @@ export class UserData {
      * Convenience method to determine if the user has any priviledges.
      * @returns {boolean} True if the user enjoys any privileges.
      */
-    get isPrivileged() : boolean {
+    get isPrivileged(): boolean {
         return this.role != UserRole.Public;
+    }
+
+    /**
+     * Extracts as an array the names of the projects this user is allowed to attach to. Notice that it can
+     * differ substantially from the projects that are available.
+     * @returns {string[]} Project names.
+     */
+    projectNames(): string[] {
+        let projNames = [];
+
+        if (this.hasOwnProperty('projects')) {
+            projNames = this['projects'].map((project) => project.accno);
+        }
+
+        return projNames;
+    }
+
+    /**
+     * Returns only the names of the available projects the user is allowed to attach to. Effectively,
+     * the list of user projects coming from the server acts as an ACL for available projects. It uses a
+     * normalised comparison of strings to intersect the two project lists.
+     * @param {string[]} availableProjects - Names of the projects that are available.
+     * @returns {string[]} Names of the allowed projects as the provided in availableProjects list.
+     */
+    allowedProjects(availableProjects: string[]): string[] {
+        const lowerCaseAllowedPrj = this.projectNames().map(name => name.toLowerCase());
+
+        return availableProjects.filter(name => {
+            const lowerCasePrj = name.toLowerCase();
+
+            //The default template must be available at all times and appear first on any list.
+            return (lowerCasePrj == 'default') || lowerCaseAllowedPrj.indexOf(lowerCasePrj) != -1;
+        });
     }
 }

--- a/src/app/submission-shared/date.utils.ts
+++ b/src/app/submission-shared/date.utils.ts
@@ -10,12 +10,14 @@ export function formatDate(date: Date): string {
     let month;      //zero-padded month number
     let year;       //full year number
 
-    //
+    //Non-empty date object.
     if (date) {
         day = ('00' + date.getDate()).slice(-2);
         month = ('00' + (date.getMonth() + 1)).slice(-2);
         year = date.getFullYear();
         return [year, month, day].join('-');
+
+    //Returns an empty string instead of a zero-padded string corresponding to the start of the Unix epoch if null.
     } else {
         return '';
     }

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
@@ -5,9 +5,8 @@ import {
     EventEmitter,
     OnInit
 } from '@angular/core';
-
 import {DirectSubmitService} from './direct-submit.service';
-import {SubmissionService} from '../shared/submission.service';
+import {UserData} from "../../auth/user-data";
 
 @Component({
     selector: 'direct-submit-sidebar',
@@ -39,18 +38,17 @@ export class DirectSubmitSideBarComponent implements OnInit {
     private projectsToAttachTo: string[] = [];           //available projects fetched asynchronously
 
     constructor(private directSubmitService: DirectSubmitService,
-                private submService: SubmissionService) {
+                private userData: UserData) {
     }
 
     ngOnInit(): void {
         this.isBusy = true;
-        this.submService.getProjects()
-            .subscribe(data => {
-                this.projectsToAttachTo = data.map(s => s.accno);
-                this.isBusy = false;
-            }, () => {
-                this.isBusy = false;
-            });
+        this.userData.whenFetched.subscribe((data) => {
+            this.projectsToAttachTo = data['projects'].map(s => s.accno);
+            this.isBusy = false;
+        }, () => {
+            this.isBusy = false;
+        });
     }
 
     onToggle(e): void {

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
@@ -44,7 +44,7 @@ export class DirectSubmitSideBarComponent implements OnInit {
     ngOnInit(): void {
         this.isBusy = true;
         this.userData.whenFetched.subscribe((data) => {
-            this.projectsToAttachTo = data['projects'].map(s => s.accno);
+            this.projectsToAttachTo = this.userData.projectNames();
             this.isBusy = false;
         }, () => {
             this.isBusy = false;

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -302,10 +302,10 @@ export class SubmEditComponent implements OnInit, OnDestroy {
      */
     submitForm() {
         const wrappedSubm = this.wrap(true);
-
+const route = this.route;
         this.submService.submitSubmission(wrappedSubm).subscribe(
             resp => {
-
+const route = this.route;
                 //Updates the acccession number of a temporary submission with the one assigned by the server.
                 if (this.subm.isTemp) {
                     this.accno = resp.mapping[0].assigned;

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -5,10 +5,7 @@ import {
     ViewChild, ChangeDetectorRef
 } from '@angular/core';
 import { Location } from '@angular/common';
-import {
-    ActivatedRoute,
-    Params
-} from '@angular/router';
+import {ActivatedRoute} from '@angular/router';
 
 import {Subscription} from 'rxjs/Subscription';
 import {Observable} from 'rxjs/Observable';

--- a/src/app/submission/edit/subm-navbar/subm-navbar.component.html
+++ b/src/app/submission/edit/subm-navbar/subm-navbar.component.html
@@ -36,12 +36,14 @@
                 (click)="onNewSubmClick($event)"
                 tooltip="Create a new submission"
                 placement="left"
-                container="body">
+                container="body"
+                [disabled]="isBusy">
             <i class="fa fa-plus-circle" aria-hidden="true"></i>
             Add new
         </button>
     </div>
 </nav>
 <subm-add-dialog #addDialog
+                 [projectNames]="allowedPrj"
                  [onSubmit]="createSubmission.bind(this)">
 </subm-add-dialog>

--- a/src/app/submission/list/subm-add.component.ts
+++ b/src/app/submission/list/subm-add.component.ts
@@ -1,6 +1,5 @@
 import {Component, Input, ViewChild} from "@angular/core";
 import {ModalDirective} from "ngx-bootstrap";
-import {SubmissionType} from "../shared/submission-type.model";
 
 @Component({
     selector: 'subm-add-dialog',
@@ -8,15 +7,11 @@ import {SubmissionType} from "../shared/submission-type.model";
 })
 export class SubmAddDialogComponent {
     public projectName: string = 'Default';
-    public projectNames: string[] = [];
 
-    @Input() onSubmit: Function;    //callback for submit action
+    @Input() onSubmit: Function;            //callback for submit action
+    @Input() projectNames: string[] = [];   //names of projects with templates
     @ViewChild('bsModal')
     private modalDirective: ModalDirective;
-
-    constructor () {
-        this.projectNames = SubmissionType.listTmplNames();
-    }
 
     /**
      * Renders the modal with default values.

--- a/src/app/submission/list/subm-list.component.html
+++ b/src/app/submission/list/subm-list.component.html
@@ -62,6 +62,7 @@
     </aside>
 </container-root>
 <subm-add-dialog #addDialog
+                 [projectNames]="allowedPrj"
                  [onSubmit]="createSubmission.bind(this)">
 </subm-add-dialog>
 <confirm-dialog #confirmDialog></confirm-dialog>

--- a/src/app/submission/shared/submission-type.model.ts
+++ b/src/app/submission/shared/submission-type.model.ts
@@ -314,6 +314,10 @@ export class SectionType extends BaseType {
 export class SubmissionType extends BaseType {
     readonly sectionType: SectionType;
 
+    static defaultTmplName() {
+        return DefaultTemplate.name;
+    }
+
     static createDefault(): SubmissionType {
         return SubmissionType.fromTemplate('');
     }


### PR DESCRIPTION
Different users will have been granted different rights regarding which projects they can attach submissions to. Therefore, the list of templates available to the user should inevitably be limited to the projects the user in question has been given rights for. This is what this update does, treating the list of projects as part of the logged-in user's data. This opens up the possibility caching the said list, avoiding multiple requests for, basically, the same information within a session.