### PR TITLE
Submission form and state improvements + UI fixes

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,5 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
-
-import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/toPromise';
 
 @Injectable()

--- a/src/app/auth/user-data.spec.ts
+++ b/src/app/auth/user-data.spec.ts
@@ -6,8 +6,14 @@ import {AuthService} from './auth.service';
 import {UserSession} from './user-session';
 
 describe('UserData', () => {
+    let submService;
+
+    beforeEach(() => {
+        submService = {getProjects: () => Observable.of([])};
+    });
+
     it('should be empty when the session is not set', () => {
-        const ud = new UserData(new UserSession(), {} as AuthService);
+        const ud = new UserData(new UserSession(), {} as AuthService, submService);
         const contact = ud.contact;
         expect(contact['Name']).toBe('');
         expect(contact['E-mail']).toBe('');
@@ -21,7 +27,7 @@ describe('UserData', () => {
              email: 'vasya@pupkin.com'
          })};
         const session = new UserSession();
-        const ud = new UserData(session, checkUser as AuthService);
+        const ud = new UserData(session, checkUser as AuthService, submService);
 
         session.create('12345');
         const contact = ud.contact;
@@ -48,7 +54,7 @@ describe('UserData', () => {
             }
         })};
         const session = new UserSession();
-        const ud = new UserData(session, checkUser as AuthService);
+        const ud = new UserData(session, checkUser as AuthService, submService);
 
         session.create('123456');
         const contact = ud.contact;

--- a/src/app/file/file.service.ts
+++ b/src/app/file/file.service.ts
@@ -7,11 +7,13 @@ import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/catch';
 
 import * as _ from 'lodash';
+import {Subscription} from "rxjs/Subscription";
 
 @Injectable()
 export class FileService {
-    constructor(private http: HttpCustomClient) {
-    }
+    subscriptions: Subscription[] = [];
+
+    constructor(private http: HttpCustomClient) {}
 
     getUserDirs(): Observable<any> {
         return this.getFiles('/Groups', 1, false)
@@ -25,6 +27,6 @@ export class FileService {
     }
 
     removeFile(fullPath): Observable<any> {
-        return this.http.del(`/api/files?path=${fullPath}`);
+        return this.http.del(`/api/files?path=${encodeURIComponent(fullPath)}`);
     }
 }

--- a/src/app/help/help.component.css
+++ b/src/app/help/help.component.css
@@ -25,9 +25,6 @@ h4 {
     clear: both;
     padding-right: 1rem;
 }
-.text-block {
-    overflow: hidden;
-}
 
 /* Scales image to width of paragraphs */
 p img {
@@ -60,21 +57,4 @@ p .btn, li .btn {
     font-size: .78rem;
     top: -.3rem;
     left: -.1rem;
-}
-
-/* Makes notes stand out by means of styled boxes */
-.alert {
-    padding: 0;
-    overflow: hidden;
-    border-width: 2px;
-}
-.alert-warning .pull-left {
-    color: #dca700;
-}
-.alert .text-block {
-    border-radius: 0 4px 4px 0;
-    background: white;
-}
-.alert .pull-left, .alert .text-block {
-    padding: 10px;
 }

--- a/src/app/help/help.component.html
+++ b/src/app/help/help.component.html
@@ -25,9 +25,9 @@
                     <dt><h4>1.Listing all your studies</h4></dt>
                     <dd id="help-list" class="col-md-12">
                         <p>
-                            The first screen shown after login is the list of so-called "Submissions". Each of these is,
-                            effectively, a form with or without study data for a current or prospective BioStudies entry.
-                            In fact, there are two main categories of submissions depending on the stage they are at:
+                            The first screen shown is the list of so-called "Submissions". Each of these is,
+                            effectively, a form for a current or prospective BioStudies entry.
+                            There are two main categories of submissions depending on the stage they are at:
                         </p>
                         <ul>
                             <li>

--- a/src/app/submission-shared/date-input.component.ts
+++ b/src/app/submission-shared/date-input.component.ts
@@ -42,6 +42,7 @@ export class DateInputComponent implements ControlValueAccessor {
     public dateValue: Date;
 
     @Input() canUsePastDates?: boolean = undefined;
+    @Input() maxDate?: Date = undefined;
     @Input() isSmall?: boolean = false;
     @Input() required?: boolean = false;
     @Input() readonly?: boolean = false;
@@ -60,6 +61,22 @@ export class DateInputComponent implements ControlValueAccessor {
     constructor(config: BsDatepickerConfig, private appConfig: AppConfig, private rootEl: ElementRef) {
         config.showWeekNumbers = false;
         config.dateInputFormat = appConfig.dateInputFormat;
+    }
+
+    /**
+     * Disables past dates if so defined in the corresponding input binding. If there is none, it falls back
+     * on the app-wide config's relevant entry. Otherwise, the default behaviour is to allow past dates.
+     * Also sets the maximum date for selection only if the corresponding input binding is provided. If not,
+     * any future date can be set.
+     */
+    ngOnInit(): void {
+        if ((typeof this.canUsePastDates === 'undefined' && !this.appConfig.canUsePastDates) ||
+            (this.canUsePastDates === false)) {
+            this.datepicker.minDate = new Date(Date.now());
+        }
+        if (this.maxDate instanceof Date) {
+            this.datepicker.maxDate = this.maxDate;
+        }
     }
 
     /**
@@ -144,17 +161,6 @@ export class DateInputComponent implements ControlValueAccessor {
         document.querySelector('.bs-datepicker-container').addEventListener('click', (event) => {
             event.stopPropagation();
         });
-    }
-
-    /**
-     * Disables past dates if so defined in the corresponding input binding. If there is none, it falls back
-     * on the app-wide config's relevant entry.
-     */
-    ngOnInit(): void {
-        if ((typeof this.canUsePastDates === 'undefined' && !this.appConfig.canUsePastDates) ||
-            (this.canUsePastDates === false)) {
-            this.datepicker.minDate = new Date(Date.now());
-        }
     }
 }
 

--- a/src/app/submission-shared/pubmedid-search/pubmedid-search.component.css
+++ b/src/app/submission-shared/pubmedid-search/pubmedid-search.component.css
@@ -33,6 +33,11 @@
     padding: 2px 10px;
     white-space: normal;
 }
+.dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus {
+    color: #fff;
+    outline: 0;
+    background-color: #3c8b9f;
+}
 .open > .dropdown-menu {
     display: block;
     display: -webkit-box;

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.css
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.css
@@ -9,3 +9,7 @@
     padding: 15px 0;
     background: #fff;
 }
+
+.radio:first-of-type {
+    margin-top: 0;
+}

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.html
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.html
@@ -64,17 +64,37 @@
                         [options]="projectsToAttachTo"
                         [(ngModel)]="model.projects"></multi-select>
             </div>
-            <div class="btn-group" dropdown [isDisabled]="isBusy">
+            <div class="form-group">
+                <label class="control-label">Action</label>
+                <div class="radio">
+                    <label>
+                        <input type="radio"
+                               class="project-radio"
+                               name="submitType"
+                               value="create"
+                               [(ngModel)]="submitType">
+                        Create a new study
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio"
+                               class="project-radio"
+                               name="submitType"
+                               value="update"
+                               [(ngModel)]="submitType">
+                        Update a study
+                    </label>
+                </div>
+            </div>
+            <div class="btn-group">
                 <button id="single-button"
                         type="button"
-                        class="btn-submit btn btn-primary"
-                        dropdownToggle>
-                    Submit as <span class="caret"></span>
+                        [disabled]="isBusy"
+                        (click)="onSubmit(submitType)"
+                        class="btn-submit btn btn-primary">
+                    Submit
                 </button>
-                <ul *dropdownMenu role="menu" aria-labelledby="single-button" class="dropdown-menu">
-                    <li role="menuitem"><a class="dropdown-item" (click)="onSubmit('create')">Create</a></li>
-                    <li role="menuitem"><a class="dropdown-item" (click)="onSubmit('update')">Update</a></li>
-                </ul>
             </div>
         </form>
     </div>

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
@@ -15,6 +15,8 @@ import {UserData} from "../../auth/user-data";
 })
 
 export class DirectSubmitSideBarComponent implements OnInit {
+    submitType: string = 'create';
+
     @Input() collapsed? = false;
     @Input() readonly? = false;
     @Output() toggle? = new EventEmitter();

--- a/src/app/submission/direct-submit/direct-submit.component.html
+++ b/src/app/submission/direct-submit/direct-submit.component.html
@@ -20,8 +20,17 @@
                 <div *ngIf="!request" class="panel-body">
                     <h4>New direct submission</h4>
                     <p>Please fill in the form on the left. A data file must be provided and may be attached
-                        to one or multiple projects. If updating an existing study, the filename must match the study's
-                        accession number.</p>
+                        to one or multiple projects.
+                    </p>
+                    <div class="alert alert-warning">
+                        <div class="pull-left">
+                            <i class="fa fa-hand-o-right fa-lg"></i>
+                            <strong>Please note</strong>
+                        </div>
+                        <p class="text-block text-black">
+                            If updating an existing study, the filename must match the study's accession number.
+                        </p>
+                    </div>
                 </div>
                 <div *ngIf="request && request.inprogress" class="panel-body">
                     <h4>Submitting study...</h4>
@@ -30,12 +39,48 @@
                 </div>
                 <div *ngIf="request && request.failed" class="panel-body">
                     <h4>Error while submitting study</h4>
-                    <p>The submitted data file is invalid or an unexpected error was encountered. Try to correct at least the
+                    <p>The submitted data file is invalid or an unexpected error was encountered. Try to correct the
                     issues highlighted in red and submit again.</p>
                 </div>
                 <div *ngIf="request && request.successful" class="panel-body">
-                    <h4>Submitted study</h4>
-                    <p>The study has been added to the BioStudies database with accession number <strong>{{request.accno}}</strong>.</p>
+                    <h4>Study {{request.type ? 'updated' : 'created'}}</h4>
+                    <p>
+                        The study with accession number
+                        <strong>{{request.accno}}</strong>
+                        <span *ngIf="request.releaseDate">
+                            and release date <strong>{{request.releaseDate | date: 'dd MMMM yyyy'}}</strong>
+                        </span>
+                        <span *ngIf="request.type">
+                            has been successfully updated.
+                        </span>
+                        <span *ngIf="!request.type">
+                            has been successfully added to the BioStudies database.
+                        </span>
+                        It {{request.type ? 'is available' : 'will be available in the next 24 hours'}} at
+                        <a target="_blank" href="{{location.origin}}/biostudies/studies/{{accno}}">
+                            {{location.hostname}}/biostudies/studies/{{request.accno}}</a>.
+                    </p>
+                    <strong>
+                        <a target="_blank" href="https://www.ebi.ac.uk/biostudies/about.html">
+                            Citing my study
+                            <i class="fa fa-fw fa-external-link-square"></i>
+                        </a>
+                    </strong>
+                    <blockquote class="blockquote">
+                        Data are available in the BioStudies database (http://www.ebi.ac.uk/biostudies)
+                        under accession number {{request.accno}}.
+                    </blockquote>
+                    <strong>
+                        <a target="_blank" href="http://europepmc.org/abstract/MED/26700850">
+                            Citing the BioStudies database
+                            <i class="fa fa-fw fa-external-link-square"></i>
+                        </a>
+                    </strong>
+                    <blockquote class="blockquote">
+                        McEntyre J, Sarkans U, Brazma A (2015) The
+                        BioStudies database. <i>Mol. Syst. Biol.</i> 11(12):847.
+                        https://doi.org/10.15252/msb.20156658.
+                    </blockquote>
                 </div>
             </div>
             <div *ngIf="request" class="panel panel-default">

--- a/src/app/submission/direct-submit/direct-submit.component.ts
+++ b/src/app/submission/direct-submit/direct-submit.component.ts
@@ -17,10 +17,17 @@ export class DirectSubmitComponent implements OnInit, OnDestroy {
     request: DirectSubmitRequest;
     collapseSideBar: Boolean = false;
 
-    constructor(private submitService: DirectSubmitService, private appConfig: AppConfig) {
-
-        //Initally collapses the sidebar for tablet-sized screens
+    /**
+     * Initally collapses the sidebar for tablet-sized screens.
+     * @param {DirectSubmitService} submitService - Singleton service for all submission transactions.
+     * @param {AppConfig} appConfig - Global configuration object with app-wide settings.
+     */
+    constructor(private submitService: DirectSubmitService, public appConfig: AppConfig) {
         this.collapseSideBar = window.innerWidth < this.appConfig.tabletBreak;
+    }
+
+    get location() {
+        return window.location;
     }
 
     ngOnInit(): void {

--- a/src/app/submission/direct-submit/direct-submit.service.ts
+++ b/src/app/submission/direct-submit/direct-submit.service.ts
@@ -21,6 +21,7 @@ export class DirectSubmitRequest {
     private _status: ReqStatus;
     private _log: any;
     private _accno: string =  '';
+    private _releaseDate: string;
 
     constructor(filename: string, format: string, projects: string[], type: ReqType) {
         this._filename = filename;
@@ -80,8 +81,12 @@ export class DirectSubmitRequest {
         return this._log || {};
     }
 
-    get accno(): any {
+    get accno(): string {
         return this._accno;
+    }
+
+    get releaseDate(): string {
+        return this._releaseDate;
     }
 
     //Handler for responses from conversion or final submission
@@ -100,6 +105,16 @@ export class DirectSubmitRequest {
             //If the response is from final submit request, exposes the accession number
             if (successStatus == ReqStatus.SUCCESS) {
                 this._accno = res.mapping[0].assigned;
+
+            //If back from conversion, extracts the release date if found.
+            } else if (successStatus == ReqStatus.SUBMIT) {
+                const dateAttr = res.document.submissions[0].attributes.find(attribute => {
+                    return attribute.name == 'ReleaseDate';
+                });
+
+                if (dateAttr) {
+                    this._releaseDate = dateAttr.value;
+                }
             }
         }
     }

--- a/src/app/submission/edit/subm-edit.component.html
+++ b/src/app/submission/edit/subm-edit.component.html
@@ -30,12 +30,20 @@
                     <div class="panel-body">
                         <h4>New submission</h4>
                         <p>
-                            Please fill in the form below. All fields are required unless with a
-                            <span class="text-dashed">&nbsp;dashed outline&nbsp;</span> or
-                            marked as "<i>Optional</i>".<br> The <span class="font-bold">Check</span> tab on the
-                            left-hand side lists those form fields still incomplete or incorrect. Use the
+                            Please fill in the form below. The <span class="font-bold">Check</span> tab on the
+                            left-hand side lists those fields still incomplete or incorrect. Use the
                             <span class="font-bold">Add</span> tab to quickly add new rows or tables.
                         </p>
+                        <div class="alert alert-warning">
+                            <div class="pull-left">
+                                <i class="fa fa-hand-o-right fa-lg"></i>
+                                <strong>Please note</strong>
+                            </div>
+                            <p class="text-block text-black">
+                                All fields are required unless with a
+                                <span class="text-dashed">&nbsp;dashed outline&nbsp;</span> or marked as "<i>Optional</i>"
+                            </p>
+                        </div>
                     </div>
                 </div>
 
@@ -43,12 +51,20 @@
                     <div class="panel-body">
                         <h4>Incomplete submission</h4>
                         <p>
-                            Some information in this submission is still missing or incorrect. Please note that all
-                            fields are required unless with a <span class="text-dashed">
-                            &nbsp;dashed outline&nbsp;</span> or marked as "<i>Optional</i>".
-                            You can find the list of fields that need updating under the
-                            <span class="font-bold">Check</span> tab on the left-hand side.
+                            Some information in this submission is still missing or incorrect. Refer to the
+                            <span class="font-bold">Check</span> tab on the left-hand side for the
+                            list of fields that need updating.
                         </p>
+                        <div class="alert alert-warning">
+                            <div class="pull-left">
+                                <i class="fa fa-hand-o-right fa-lg"></i>
+                                <strong>Please note</strong>
+                            </div>
+                            <p class="text-block text-black">
+                                All fields are required unless with a
+                                <span class="text-dashed">&nbsp;dashed outline&nbsp;</span> or marked as "<i>Optional</i>"
+                            </p>
+                        </div>
                     </div>
                 </div>
 
@@ -68,7 +84,7 @@
                             <h4>Study ready for re-submission</h4>
                             <p>
                                 You may re-submit the data on this form now. Your study will retain
-                                the same accession number under which it was published.
+                                the same accession number under which it was registered.
                             </p>
                         </div>
                     </div>
@@ -83,8 +99,56 @@
 
                 <div *ngIf="!subm.isTemp && readonly" class="panel">
                     <div class="panel-body">
-                        <h4>Submitted study</h4>
-                        <p>The study has been added to the BioStudies database with accession number <strong>{{accno}}</strong>.</p>
+                        <h4>Study
+                            <span *ngIf="isUpdate == undefined">
+                                entry
+                            </span>
+                            <span *ngIf="isUpdate == false">
+                                created
+                            </span>
+                            <span *ngIf="isUpdate">
+                                updated
+                            </span>
+                        </h4>
+                        <p>
+                            The study with accession number <strong>{{accno}}</strong>
+                            <span *ngIf="releaseDate">
+                                and release date <strong>{{releaseDate | date: 'dd MMMM yyyy'}}</strong>
+                            </span>
+                            <span *ngIf="isUpdate == undefined">
+                                is present on the BioStudies database with the data shown below.
+                            </span>
+                            <span *ngIf="isUpdate == false">
+                                has been successfully added to the BioStudies database.
+                            </span>
+                            <span *ngIf="isUpdate">
+                                has been successfully updated.
+                            </span>
+                            It {{isUpdate == false ? 'will be available in the next 24 hours' : 'is available' }} at
+                            <a target="_blank" href="{{location.origin}}/biostudies/studies/{{accno}}">
+                            {{location.hostname}}/biostudies/studies/{{accno}}</a>.
+                        </p>
+                        <strong>
+                            <a target="_blank" href="https://www.ebi.ac.uk/biostudies/about.html">
+                                Citing my study
+                                <i class="fa fa-fw fa-external-link-square"></i>
+                            </a>
+                        </strong>
+                        <blockquote class="blockquote">
+                            Data are available in the BioStudies database (http://www.ebi.ac.uk/biostudies)
+                            under accession number {{accno}}.
+                        </blockquote>
+                        <strong>
+                            <a target="_blank" href="http://europepmc.org/abstract/MED/26700850">
+                                Citing the BioStudies database
+                                <i class="fa fa-fw fa-external-link-square"></i>
+                            </a>
+                        </strong>
+                        <blockquote class="blockquote">
+                            McEntyre J, Sarkans U, Brazma A (2015) The
+                            BioStudies database. <i>Mol. Syst. Biol.</i> 11(12):847.
+                            https://doi.org/10.15252/msb.20156658.
+                        </blockquote>
                     </div>
                 </div>
 

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -22,6 +22,7 @@
         [(ngModel)]="value"
         [required]="required"
         [readonly]="readonly"
+        [maxDate]="nowInNyears(2)"
         (focusout)="onBlur()">
 </date-input>
 

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -123,4 +123,14 @@ export class SubmFieldComponent implements ControlValueAccessor {
     onSuggestSelect(selection: TypeaheadMatch) {
         this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
     }
+
+    /**
+     * Convenience method for the equivalen date n years into the future.
+     * @param {number} years - Number of years the date is incremented in.
+     * @returns {Date} - Resulting date object.
+     */
+    nowInNyears(years: number = 0): Date {
+        const currDate = new Date();
+        return new Date(currDate.setFullYear(currDate.getFullYear() + years));
+    }
 }

--- a/src/app/submission/edit/subm-form/subm-form.service.ts
+++ b/src/app/submission/edit/subm-form/subm-form.service.ts
@@ -67,9 +67,9 @@ export class FieldControl extends FormControl {
     /**
      * Recursively traverses a given form grouping to get all controls as a flattened array.
      * @param {FormGroup | FormArray} formGroup - Group containing all controls, regardless of any nested groups or arrays.
-     * @param {FormControl[]} controlList - Flattened array of form controls.
+     * @param {FieldControl[]} controlList - Flattened array of form controls.
      */
-    static toArray(formGroup: FormGroup | FormArray, controlList: FormControl[]) {
+    static toArray(formGroup: FormGroup | FormArray, controlList: FieldControl[]) {
 
         //Alternative to ES7's Object.values() method to get all controls within the grouping
         (<any>Object).keys(formGroup.controls).map(key => formGroup.controls[key]).forEach(control => {
@@ -81,7 +81,7 @@ export class FieldControl extends FormControl {
                 controlList.push(control);
 
                 //Keeps track of controls that have been modified but still invalid
-                if (control.touched && control.invalid) {
+                if (control.touched && control.invalid && control.parentType.required) {
                     this.numPending++;
                 }
             }
@@ -187,9 +187,9 @@ export class SectionForm {
     /**
      * Traverses the form in its entirety in order to get all its controls, both the section's and features' controls.
      * While at it, it initialises the current number of pending fields.
-     * @param {FormControl[]} controls - Final array with all the form's controls.
+     * @param {FieldControl[]} controls - Final array with all the form's controls.
      */
-    controls(controls: FormControl[]) {
+    controls(controls: FieldControl[]) {
         FieldControl.numPending = 0;
 
         controls.length = 0;

--- a/src/app/submission/list/subm-add.component.html
+++ b/src/app/submission/list/subm-add.component.html
@@ -1,11 +1,11 @@
 <div bsModal class="modal fade" role="dialog" aria-hidden="true"
      #bsModal="bs-modal"
-     (onShown)="onShown(focusBtn)">
+     (onShown)="onShown()">
     <div class="modal-dialog">
         <div class="modal-content">
             <form novalidate autocomplete="off"
                   #form="ngForm"
-                  (ngSubmit)="onSubmit(projectName)">
+                  (ngSubmit)="bsModal.hide(); onSubmit(projectName)">
                 <div class="modal-header bg-primary">
                     Add new submission
                     <button type="button" class="close pull-right" aria-label="Close" (click)="hide()">
@@ -20,6 +20,7 @@
                         <div *ngFor="let name of projectNames" class="radio">
                             <label>
                                 <input type="radio"
+                                       class="project-radio"
                                        [name]="name"
                                        [value]="name"
                                        [(ngModel)]="projectName">
@@ -30,8 +31,7 @@
                 </div>
                 <div class="modal-footer">
                     <div class="pull-right">
-                        <button type="submit" class="btn btn-primary btn-sm"
-                                #focusBtn>
+                        <button type="submit" class="btn btn-primary btn-sm">
                             Add
                         </button>
                         <button type="button"

--- a/src/app/submission/list/subm-add.component.ts
+++ b/src/app/submission/list/subm-add.component.ts
@@ -29,9 +29,10 @@ export class SubmAddDialogComponent {
 
     /**
      * Handler for "onShown" event, triggered exactly after the modal has been fully revealed.
+     * It sets focus on the first radio button for project selection.
      */
-    onShown(focusEl: HTMLElement): void {
-        focusEl.focus();
+    onShown(): void {
+        (<HTMLInputElement>document.getElementsByClassName('project-radio')[0]).focus();
     }
 
     /**
@@ -39,7 +40,6 @@ export class SubmAddDialogComponent {
      */
     onCancel(): void {
         this.projectName = 'Default';
-        //this.typeName.control.reset();
         this.hide();
     }
 }

--- a/src/app/submission/list/subm-list.component.html
+++ b/src/app/submission/list/subm-list.component.html
@@ -16,7 +16,8 @@
                     [disabled]="isBusy"
                     tooltip="Create a new submission manually"
                     container="body">
-                <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                <i *ngIf="!isCreating" class="fa fa-plus-circle" aria-hidden="true"></i>
+                <i *ngIf="isCreating" class="fa fa-cog fa-spin"></i>
                 <span>Add new</span>
             </button>
         </span>
@@ -57,7 +58,7 @@
             </div>
         </section>
         <a href="https://www.ebi.ac.uk/biostudies/studies/" target="_blank">
-            <i class="fa fa-fw fa-external-link-square"></i>Search published submissions
+            Search published submissions <i class="fa fa-fw fa-external-link-square"></i>
         </a>
     </aside>
 </container-root>

--- a/src/app/submission/results/results-log-node.component.ts
+++ b/src/app/submission/results/results-log-node.component.ts
@@ -15,6 +15,11 @@ export class ResultsLogNodeComponent implements TreeViewCustomNodeComponent {
     onNodeData(data: any = {}): void {
         this._message = data.message || '';
         this._logLevel = (data.level || 'info').toLowerCase();
+
+        //Makes parent ERRORS display as normal info nodes.
+        if (data.subnodes && this._logLevel == 'error') {
+            this._logLevel = 'info';
+        }
     }
 
     get message(): string {

--- a/src/app/submission/results/subm-results-modal.component.html
+++ b/src/app/submission/results/subm-results-modal.component.html
@@ -16,9 +16,7 @@
         <div class="media-body media-middle">
             <p class="media-heading">
                 <span *ngIf="isSuccess()">
-                    Your submission has been successfully added to the BioStudies database with accession number <strong>{{accno}}</strong>. It
-                    will be available in the next 24 hours at <a target="_blank" href="{{location.origin}}/biostudies/studies/{{accno}}">
-                    {{location.hostname}}/biostudies/studies/{{accno}}</a>.
+                    Your submission has been successfully {{isUpdate ? 'updated' : 'added to the BioStudies database'}}.
                 </span>
                 <span *ngIf="!isSuccess()">
                     An error has occurred while submitting the data to BioStudies. You may review your submission and try again. If the error
@@ -29,6 +27,26 @@
                 </span>
             </p>
         </div>
+    </div>
+    <div  *ngIf="isSuccess() && !isUpdate" class="alert alert-warning">
+        <div class="pull-left">
+            <i class="fa fa-hand-o-right fa-lg"></i>
+            <strong>Please note</strong>
+        </div>
+        <p class="text-block text-black">
+            The system may take up to 24 hours after submission to register any new studies in the
+            database.
+        </p>
+    </div>
+    <div  *ngIf="isSuccess() && !isUpdate" class="alert alert-warning">
+        <div class="pull-left">
+            <i class="fa fa-hand-o-right fa-lg"></i>
+            <strong>Please note</strong>
+        </div>
+        <p class="text-block text-black">
+            Any registered study will remain private and accessible only through login
+            until the release date.
+        </p>
     </div>
     <subm-results-tree *ngIf="!isLogEmpty() && !isSuccess()" [log]="log"></subm-results-tree>
 </div>

--- a/src/app/submission/results/subm-results-modal.component.ts
+++ b/src/app/submission/results/subm-results-modal.component.ts
@@ -20,14 +20,9 @@ export class SubmResultsModalComponent {
     @Input() status: string;        //Status the server comes back with
     @Input() accno: string;         //Submission's accession number
     @Input() log: any;              //Log part of the server's response
+    @Input() isUpdate: boolean;     //Indicates if the results come from updating a submission.
 
-    constructor(private router: Router,
-                public bsModalRef: BsModalRef) {
-    }
-
-    get location() {
-        return window.location;
-    }
+    constructor(private router: Router, public bsModalRef: BsModalRef) {}
 
     isLogEmpty() {
         return this.log && Object.keys(this.log).length == 0;

--- a/src/app/submission/shared/default.template.ts
+++ b/src/app/submission/shared/default.template.ts
@@ -5,8 +5,8 @@ export const DefaultTemplate = {
         'name': 'Study',
         'annotationsType': {
             'title': 'Describe your study',
-            'description': 'Provide any supplementary details of the study that may help discover and/or interpret it ' +
-                           'such as organism, cell type or experimental design.',
+            'description': 'Provide any additional details that may help discover or interpret the study. For example, ' +
+                           'organism, cell type or experimental design.',
             'icon': 'fa-tag',
             'columnTypes': [
                 {
@@ -235,8 +235,7 @@ export const DefaultTemplate = {
             {
                 'name': 'Link',
                 'title': 'Add Links',
-                'description': 'Provide pointers to data held in other databases, or to associated information on the ' +
-                               'web, to enable a complete overview of a study.',
+                'description': 'Provide pointers to data held in external databases or to related information on the web.',
                 'icon': 'fa-link',
                 'uniqueCols': true,
                 'columnTypes': [
@@ -259,7 +258,7 @@ export const DefaultTemplate = {
             {
                 'name': 'Publication',
                 'title': 'Add Publications',
-                'description': 'Add the details of publications relevant or complementary to the study. Autofill is ' +
+                'description': 'Add the details of publications relevant to the study. Autofill is ' +
                                'available when searching by PubMed identifier',
                 'icon': 'fa-book',
                 'uniqueCols': true,

--- a/src/app/submission/shared/hecatos.template.ts
+++ b/src/app/submission/shared/hecatos.template.ts
@@ -7,8 +7,8 @@ export const HecatosTemplate = {
         'annotationsType': {
             'title': 'Describe your study',
             'icon': 'fa-tag',
-            'description': 'Provide any supplementary details of the study that may help discover and/or interpret it ' +
-                           'such as experimental factors.',
+            'description': 'Provide any factors that may help discover or interpret the study. For example, ' +
+                           'age, dose frequency or time range.',
             'columnTypes': [
                 {
                     'name': 'Factor',
@@ -50,116 +50,82 @@ export const HecatosTemplate = {
                 'minlength': 50
             },
             {
-                'name': 'Design Type',
-                'valueType': 'text'
-            },
-            {
-                'name': 'Assay Measurement Type',
-                'valueType': 'text'
-            },
-            {
-                'name': 'Assay Technology Type',
-                'valueType': 'text'
-            },
-            {
-                'name': 'Assay Technology Platform',
-                'valueType': 'text'
-            },
-            {
-                'name': 'Organism',
+                'name': 'Sample Type',
+                'icon': 'fa-eyedropper',
                 'valueType': 'text',
-                'values': [
-                    'Homo sapiens',
-                    'Mus musculus',
-                    'Arabidopsis thaliana',
-                    'Rattus norvegicus',
-                    'Drosophila melanogaster',
-                    'Oryza sativa Japonica Group',
-                    'Anas platyrhyncho',
-                    'Anolis carolinensis',
-                    'Anopheles gambiae',
-                    'Arabidopsis lyrata',
-                    'Aspergillus fumigatus',
-                    'Bos Taurus',
-                    'Brachypodium distachyon',
-                    'Brassica oleracea',
-                    'Brassica rapa',
-                    'Caenorhabditis elegans',
-                    'Canis familiaris',
-                    'Chlorocebus sabaeus',
-                    'Ciona intestinalis',
-                    'Ciona savignyi',
-                    'Danio rerio',
-                    'Dasypus novemcinctus',
-                    'Equus caballus',
-                    'Gallus gallus',
-                    'Glycine max',
-                    'Gorilla gorilla',
-                    'Hordeum vulgare',
-                    'Macaca mulatta',
-                    'Medicago truncatula',
-                    'Monodelphis domestica',
-                    'Musa acuminate',
-                    'Ornithorhynchus anatinus',
-                    'Oryctolagus cuniculus',
-                    'Oryza rufipogon',
-                    'Ovis aries',
-                    'Pan troglodytes',
-                    'Papio Anubis',
-                    'Physcomitrella patens',
-                    'Pongo abelii',
-                    'Populus trichocarpa',
-                    'Saccharomyces cerevisiae',
-                    'Schistosoma mansoni',
-                    'Schizosaccharomyces pombe',
-                    'Solanum lycopersicum',
-                    'Solanum tuberosum',
-                    'Sorghum bicolor',
-                    'Sus scrofa',
-                    'Tetraodon nigroviridis',
-                    'Theobroma cacao',
-                    'Triticum aestivum',
-                    'Vitis vinifera',
-                    'Xenopus tropicalis',
-                    'Yarrowia lipolytica',
-                    'Zea mays'
-                ]
+                'values': ['Cardiac microtissue', 'Heart biopsy', 'Liver microtissue', 'Liver biopsy', 'Serum sample']
             },
             {
                 'name': 'Organ',
-                'valueType': 'text'
+                'icon': 'fa-eyedropper',
+                'valueType': 'text',
+                'values': ['Heart', 'Liver']
             },
             {
-                'name': 'Sample Type',
-                'valueType': 'text'
+                'name': 'Organism',
+                'icon': 'fa-eyedropper',
+                'valueType': 'text',
+                'values': ['Homo sapiens', 'Sus scrofa']
+            },
+            {
+                'name': 'Dose',
+                'icon': 'fa-eyedropper',
+                'valueType': 'text',
+                'values': ['Therapeutic', 'Toxic', 'Control', '0.1% DMSO', 'Fluctuating DMSO']
             },
             {
                 'name': 'Biological Replicate',
+                'icon': 'fa-eyedropper',
                 'valueType': 'text'
             },
             {
                 'name': 'Compound',
-                'valueType': 'text'
+                'icon': 'fa-flask',
+                'valueType': 'text',
+                'values': ['Doxorubicin', 'Epirubicin', 'Idarubicin', 'DMSO', 'Untreated']
             },
             {
                 'name': 'Chembl ID',
-                'valueType': 'text'
+                'icon': 'fa-flask',
+                'valueType': 'text',
+                'values': ['CHEMBL53463', 'CHEMBL417', 'CHEMBL1117']
             },
             {
                 'name': 'Std In Chi Key',
+                'icon': 'fa-flask',
+                'valueType': 'text',
+                'values': ['AOJJSUZBOXZQNB-TZSSRYMLSA-N', 'AOJJSUZBOXZQNB-VTZDEGQISA-N', 'XDXDZDZNSLXDNA-TZNDIEGXSA-N']
+            },
+            {
+                'name': 'Design Type',
+                'icon': 'fa-cogs',
                 'valueType': 'text'
             },
             {
-                'name': 'Dose',
+                'name': 'Assay Measurement Type',
+                'icon': 'fa-cogs',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Assay Technology Type',
+                'icon': 'fa-cogs',
+                'valueType': 'text'
+            },
+            {
+                'name': 'Assay Technology Platform',
+                'icon': 'fa-cogs',
                 'valueType': 'text'
             },
             {
                 'name': 'Protocol Type',
+                'icon': 'fa-cogs',
                 'valueType': 'text'
             },
             {
                 'name': 'Data Type',
-                'valueType': 'text'
+                'icon': 'fa-cogs',
+                'valueType': 'text',
+                'values': ['Genomic data', 'Proteomics data', 'Metabolomic data']
             }
         ],
         'featureTypes': [
@@ -263,8 +229,7 @@ export const HecatosTemplate = {
             {
                 'name': 'Link',
                 'title': 'Add Links',
-                'description': 'Provide pointers to data held in other databases, or to associated information on the ' +
-                               'web, to enable a complete overview of a study.',
+                'description': 'Provide pointers to data held in external databases or to related information on the web.',
                 'icon': 'fa-link',
                 'uniqueCols': true,
                 'columnTypes': [
@@ -287,7 +252,7 @@ export const HecatosTemplate = {
             {
                 'name': 'Publication',
                 'title': 'Add Publications',
-                'description': 'Add the details of publications relevant or complementary to the study. Autofill is ' +
+                'description': 'Add the details of publications relevant to the study. Autofill is ' +
                                'available when searching by PubMed identifier',
                 'icon': 'fa-book',
                 'uniqueCols': true,

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -304,6 +304,12 @@ input[type="radio"] {
     color: @text-color;
   }
 }
+
+//Allows the collapse of common spacing between body and footer in a modal
+.modal-footer {
+  padding-top: 0 !important;
+}
+
 //Convenience class for bold typography
 .font-bold {
   font-weight: bold;

--- a/src/styles/misc.less
+++ b/src/styles/misc.less
@@ -12,50 +12,6 @@
   width: 70%;
 }
 
-/* sliding out tooltips in the panel headers */
-@bs-slide-out-tip-width: 580px;
-
-.bs-slide-out-tip {
-  display: inline-block;
-  position: relative;
-  margin: 0 0 0 5px;
-  padding: 0;
-  width: 70%;
-  height: 18px;
-  overflow: hidden;
-}
-
-.bs-slide-out-tip .tip-icon {
-  display: inline-block;
-  cursor: pointer;
-  width: 15px;
-}
-
-.bs-slide-out-tip .tip-text-wrap {
-  display: inline-block;
-  position: relative;
-  overflow: hidden;
-  width: 600px;
-  height: 100%;
-}
-
-.bs-slide-out-tip .tip-text {
-  position: absolute;
-  top: 0;
-  left: -@bs-slide-out-tip-width;
-  width: @bs-slide-out-tip-width;
-  display: inline-block;
-  -webkit-transition: left 0.5s ease-in-out;
-  -moz-transition: left 0.5s ease-in-out;
-  -o-transition: left 0.5s ease-in-out;
-  -ms-transition: left 0.5s ease-in-out;
-  transition: left 0.5s ease-in-out;
-}
-
-.bs-slide-out-tip .tip-text.show {
-  left: 0;
-}
-
 /* Prevents flicker when hovering over tabs */
 .nav-tabs .nav-link:hover {
   border-color: transparent;
@@ -240,6 +196,42 @@ component */
     min-width: 300px;
     font-size: 14px;
   }
+}
+
+//Prevents flickering tooltips when hovering near the edge of an element
+.tooltip {
+  pointer-events: none;
+}
+
+///Makes notes stand out by means of styled boxes
+.alert-warning {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 0;
+  overflow: hidden;
+  border-width: 2px;
+}
+.alert-warning .pull-left {
+  color: #dca700;
+}
+.alert-warning .text-block {
+  border-radius: 0 4px 4px 0;
+  background: white;
+}
+.alert-warning .pull-left, .alert-warning .text-block {
+  padding: 10px;
+}
+
+//Creates new blocking context useful for media sitting on one side.
+.text-block {
+  overflow: hidden;
+}
+
+//Normalises quotation blocks for citation examples
+.blockquote {
+  font: inherit;
+  margin: 4px 0 12px;
+  padding: .5rem 1rem;
 }
 
 //Shades an entire area, preventing any interaction as well.


### PR DESCRIPTION
- File list view fixes:
   - Fixes exception when switching from files view to submissions list before request completion.
   - Encodes file paths before deletion request to fix `File not found` server error.
- Submission form improvements (manual & direct submit)
   - Switches to check tab automatically on pressing the submit button if errors present.
   - Fixes wrong pending fields counter when required fields within optional features are highlighted.
   - Sets datepicker's maximum date to 2 years ahead for release date field.
   - Bring highlighting style for PubMed search drop-up in line with rest of the app.
   - Unpacks the "Submit as" button in the direct submit's sidebar into clear radio buttons with "Create" as a default.
- Submission results improvements (manual & direct submit)
   - Makes "Please note" box styles global and refactors submission state messages at the top. 
   - Refactors the final message after submission so that the update (re-submitted study) and create (new study) states are differentiated. 
   - Submission information is expanded to include citation tips, release date and frontend link. 
   - Applies the red colour only to leaf error nodes in log trees.
   - Scrolls back to the top after showing submissions result in case the submission form is long.
- Template improvements
   - Updates HeCaToS template with predefined values and assigns icons according to field category.
   - Improves feature descriptions for all templates. 
- Shows loading feedback after template selection in case the request for submission creation takes longer than usual.
- Updates tests for the `UserData` class after marshalling of projects list.