### PR TITLE
Error state for subm edit and other improvements

### DIFF
--- a/src/app/file/file-list.component.ts
+++ b/src/app/file/file-list.component.ts
@@ -175,7 +175,7 @@ export class FileListComponent implements OnInit, OnDestroy {
             rowSelection: 'single',
             unSortIcon: true,
             localeText: {noRowsToShow: 'No files found'},
-            overlayLoadingTemplate: '<span class="ag-overlay-loading-center"><i class="fa fa-cog fa-spin"></i> Loading...</span>',
+            overlayLoadingTemplate: '<span class="ag-overlay-loading-center"><i class="fa fa-cog fa-spin fa-lg"></i> Loading...</span>',
         };
 
         this.fileUploadService.uploadFinish$

--- a/src/app/submission/edit/subm-edit.component.html
+++ b/src/app/submission/edit/subm-edit.component.html
@@ -6,10 +6,12 @@
                   [section]="section"
                   [formControls]="formControls"
                   [errors]="errors"
-                  [isSubmitting]="isSubmitting">
+                  [isLoading]="isLoading"
+                  [isSubmitting]="isSubmitting"
+                  [serverError]="serverError">
     </subm-sidebar>
 
-    <subm-navbar class="navbar-subm-fixed navbar-default"
+    <subm-navbar *ngIf="subm" class="navbar-subm-fixed navbar-default"
             [ngClass]="{'collapse-left': !readonly && sideBarCollapsed}"
             [readonly]="readonly"
             [accno]="accno"

--- a/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
+++ b/src/app/submission/edit/subm-sidebar/subm-sidebar.component.html
@@ -1,5 +1,5 @@
 <aside class="left-side sidebar sidebar-offcanvas"
-       [ngClass]="{'collapse-left' : collapsed}">
+       [ngClass]="{'collapse-left' : collapsed, 'server-error': serverError}">
     <div class="menu-toggle">
         <button class="minimise-btn btn pull-right"
                 [ngClass]="{'inactive': !collapsed}"
@@ -23,7 +23,8 @@
                     </span>
                 </template>
             </tab>
-            <tab heading="Add"
+            <tab *ngIf="section"
+                 heading="Add"
                  [active]="!isStatus"
                  (select)="onTabClick(false)"></tab>
         </tabset>
@@ -121,12 +122,17 @@
                 <i class="fa " aria-hidden="true"
                     [ngClass]="{
                     'fa-2x': collapsed, 'fa-4x': !collapsed,
-                    'fa-check-circle': !isLoading && !isSubmitting,
+                    'fa-times-circle': serverError,
+                    'fa-check-circle': !serverError && !isLoading && !isSubmitting,
                     'fa-cog fa-spin': isLoading || isSubmitting}"></i>
                 <h4 [ngClass]="{'vertical-text': collapsed}">
-                    {{isLoading ? 'Loading study...' : isSubmitting? 'Submitting study...' : 'All fields are valid'}}
+                    {{isLoading ? 'Loading study...' :
+                                    isSubmitting? 'Submitting study...' :
+                                                    serverError ?  errorMsg() : 'All fields are valid'}}
                 </h4>
-                <h4 class="action-title">{{isLoading || isSubmitting ? 'Please wait' : 'You may submit your study now'}}</h4>
+                <h4 *ngIf="!serverError" class="action-title">
+                    {{isLoading || isSubmitting ? 'Please wait' : 'You may submit your study now'}}
+                </h4>
             </li>
             <li class="sidebar-item" *ngFor="let control of formControls; let i = index">
                 <a *ngIf="control.parentType.required && control.invalid"

--- a/src/app/submission/list/subm-list.component.ts
+++ b/src/app/submission/list/subm-list.component.ts
@@ -158,7 +158,7 @@ export class SubmListComponent {
             rowHeight: 30,
             localeText: {noRowsToShow: 'No submissions found'},
             icons: {menu: '<i class="fa fa-filter"/>'},
-            overlayLoadingTemplate: '<span class="ag-overlay-loading-center"><i class="fa fa-cog fa-spin"></i> Loading...</span>',
+            overlayLoadingTemplate: '<span class="ag-overlay-loading-center"><i class="fa fa-cog fa-spin fa-lg"></i> Loading...</span>',
             getRowNodeId: (item) => {
                 return item.accno;
             },

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -75,6 +75,18 @@ aside {
   -webkit-transition: width .3s ease;
   -moz-transition: width .3s ease;
   transition: width .3s ease;
+
+  &.server-error {
+    background: @brand-danger;
+
+    .sidebar-menu {
+      border-top-color: @brand-danger;
+    }
+  }
+
+  &.collapse-left {
+    width: @left-side-width-collapse;
+  }
 }
 
 .right-side.collapse-left {
@@ -84,10 +96,6 @@ aside {
 
 .navbar-subm-fixed.collapse-left {
   padding-left: @left-side-width-collapse;
-}
-
-.left-side.collapse-left {
-  width: @left-side-width-collapse;
 }
 
 @media screen and (max-width: @screen-md) {
@@ -265,6 +273,7 @@ aside {
 }
 
 //Makes unselected tabs be on a plane behind selected ones with a permanent shaded appearance. Also bumps up their weight
+//and changes the background to reflect a server error.
 .nav-tabs > .nav-item > .nav-link {
   font-weight: 500;
 }
@@ -273,6 +282,10 @@ aside {
 }
 .nav-tabs > .nav-item > .nav-link.active {
   z-index: 100;
+
+  .server-error & {
+    background: @brand-danger;
+  }
 }
 
 //Gives readonly inputs and features the appearance of standard text


### PR DESCRIPTION
- Normalises error messages coming from the server when retrieving a certain submission and shows them on the side-bar. This means that alerts won't be used in this case.
- Hides the navbar and the "Add" tab to reflect the absence of a submission if retrieval fails.
- Makes the cog animation for Ag-Grid's loading state slightly bigger.