### PR TITLE
Graceful recovery from file upload errors

### DIFF
--- a/src/app/core/header/global-error.component.html
+++ b/src/app/core/header/global-error.component.html
@@ -3,5 +3,5 @@
             (click)="onClose()">
         <i class="fa fa-times"></i>
     </button>
-    <span class="message-container">{{error}}</span>
+    <span class="message-container">{{message}}</span>
 </div>

--- a/src/app/file/file-list.component.ts
+++ b/src/app/file/file-list.component.ts
@@ -29,6 +29,7 @@ import 'rxjs/add/operator/filter';
 import {AppConfig} from "../app.config";
 import "rxjs/add/operator/takeUntil";
 import {Subject} from "rxjs/Subject";
+import {Observable} from "rxjs/Observable";
 
 @Component({
     selector: 'file-actions-cell',
@@ -111,7 +112,7 @@ export class FileTypeCellComponent implements AgRendererComponent {
                 [ngStyle]="{ 'width': value + '%'}">{{value}}%</div>
     </div>
     <div *ngIf="value === 100" style="text-align:center;color:green"><i class="fa fa-check"></i></div>
-    <div *ngIf="value < 0" class="text-danger">{{error}}</div>
+    <div *ngIf="value < 0" class="text-danger text-center"><i class="fa fa-times-circle"></i> {{error}}</div>
 `
 })
 export class ProgressCellComponent implements AgRendererComponent {
@@ -250,7 +251,12 @@ export class FileListComponent implements OnInit, OnDestroy {
         let p: Path = path ? path : this.path;
         this.fileService.getFiles(p.fullPath())
             .takeUntil(this.ngUnsubscribe)
-            .subscribe(
+
+            .catch(error => {
+                this.gridOptions.api.hideOverlay();
+                return Observable.throw(error);
+
+            }).subscribe(
                 data => {
                     if (data.status === 'OK') { //use proper http codes for this!!!!!!
                         this.path = p;

--- a/src/app/file/file-upload-badge.component.html
+++ b/src/app/file/file-upload-badge.component.html
@@ -1,8 +1,11 @@
 <div *ngIf="count > 0" dropdown>
-    <button class="badge btn" dropdownToggle>{{count}}</button>
+    <button class="badge btn" dropdownToggle
+            [ngClass]="{'badge-danger': hasFailed}">
+        {{count}}
+    </button>
     <ul class="dropdown-menu dropdown-menu-right" *dropdownMenu role="menu">
-        <li role="menuitem" *ngFor="let u of uploads">
-            <a class="dropdown-item" (click)="onMenuItemClick(u)">Show <i>{{u.name}}</i> in path</a>
+        <li role="menuitem" *ngFor="let upload of uploads">
+            <a class="dropdown-item" (click)="onMenuItemClick(upload)">Show <i>{{upload.name}}</i> in path</a>
         </li>
     </ul>
 </div>

--- a/src/app/file/file-upload.service.ts
+++ b/src/app/file/file-upload.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {ErrorHandler, Injectable} from '@angular/core';
 import {Subject} from 'rxjs/Subject';
 import {Observable} from 'rxjs/Observable';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
@@ -13,6 +13,7 @@ import {HttpCustomClient} from 'app/http/http-custom-client.service'
 import {Path} from './path';
 
 import * as _ from 'lodash';
+import {ServerError} from "../http/server-error.handler";
 
 const FILE_UPLOAD_URL = '/raw/fileUpload'; 
 
@@ -35,12 +36,12 @@ export class FileUpload {
 
     finish$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
-    constructor(path: Path, files: File[], httpClient: HttpCustomClient) {
+    constructor(path: Path, files: File[], httpClient: HttpCustomClient, globalHandler: ErrorHandler) {
         this._path = path;
         this._files = _.map(files, 'name');
         this._progress = 0;
 
-        const failed = Observable.of(new FileUploadStatus('error', -1, 'file upload failed'));
+        const failed = Observable.of(new FileUploadStatus('error', -1, 'Upload failure.'));
 
         let upload = httpClient.upload(FILE_UPLOAD_URL, files, path.fullPath());
 
@@ -53,8 +54,9 @@ export class FileUpload {
                     return new FileUploadStatus('success', 100, undefined);
                 }
             })
-            .catch((err) => {
-                console.log(err);
+            .catch((error) => {
+                console.log(error);
+                globalHandler.handleError(ServerError.fromResponse(error));
                 return failed;
             });
 
@@ -119,27 +121,47 @@ export class FileUpload {
 
 @Injectable()
 export class FileUploadService {
-    private _uploads: FileUpload[] = [];
+    private _uploads: FileUpload[] = [];        //Batches of file uploads
     uploadFinish$: Subject<string> = new Subject<string>();
 
-    constructor(private http: HttpCustomClient) {
-    }
+    constructor(private http: HttpCustomClient, private globalHandler: ErrorHandler) {}
 
+    /**
+     * Retrieves only the upload requests that are still in progress.
+     * @returns {FileUpload[]} Deep-cloned collection with incomplete requests filtered out.
+     */
     activeUploads(): FileUpload[] {
-        return _.filter(_.map(this._uploads, _.identity), (u) => !u.done());
+        return _.filter(_.map(this._uploads, _.identity), (upload) => !upload.done());
     }
 
+    /**
+     * Starts the request process for the selected files and keeps track of it.
+     * NOTE: Multiple-file uploads are allowed. Each group of simultaneous uploads is bundled into one request.
+     * @see {@link FileUpload}
+     * @see {@link UploadService}
+     * @param {Path} path - Path common to all files to be uploaded.
+     * @param {File[]} files - Files to be uploaded.
+     * @returns {FileUpload} Tracking object for the resulting upload request.
+     */
     upload(path: Path, files: File[]): FileUpload {
-        let u = new FileUpload(path, files, this.http);
-        this._uploads.push(u);
-        u.finish$.filter(_.identity)
-            .map(() => u.path.fullPath())
-            .subscribe((path) => this.uploadFinish$.next(path)); // do not subscribe uploadFinish$ directly here.
-        // as cancellation of finish$ will cancel uploadFinish$ as well
-        return u;
+        let upload = new FileUpload(path, files, this.http, this.globalHandler);
+
+        this._uploads.push(upload);
+        upload.finish$.filter(_.identity)
+            .map(() => upload.path.fullPath())
+
+            // do not subscribe uploadFinish$ directly here.
+            // as cancellation of finish$ will cancel uploadFinish$ as well
+            .subscribe((path) => this.uploadFinish$.next(path));
+
+        return upload;
     }
 
-    remove(u: FileUpload) {
-        _.pull(this._uploads, u);
+    /**
+     * Removes a given upload request from the collection.
+     * @param {FileUpload} upload - Group of simultaneously uploaded files.
+     */
+    remove(upload: FileUpload) {
+        _.pull(this._uploads, upload);
     }
 }

--- a/src/app/http/http-custom-client.service.ts
+++ b/src/app/http/http-custom-client.service.ts
@@ -64,6 +64,8 @@ export class HttpCustomClient {
         for (let fi of files) {
             input.append('file', fi);
         }
+
+        //TODO: The error handler is only allowed within whatever routine calls the "upload" method. It should be brought back to this layer so that a "catch" can be used, just like with the other REST verb operations.
         return this.uploadService.post(this.transform(url), input, this.headers());
     }
 

--- a/src/app/submission/list/subm-list.component.ts
+++ b/src/app/submission/list/subm-list.component.ts
@@ -240,6 +240,7 @@ export class SubmListComponent {
                     const fm = params.filterModel || {};
                     this.isBusy = true;
 
+                    //Shows loading progress overlay box.
                     if (agApi != null) {
                         agApi.showLoadingOverlay();
                     }
@@ -254,10 +255,16 @@ export class SubmListComponent {
                         rTimeTo: fm.rtime && fm.rtime.value && fm.rtime.value.to ? fm.rtime.value.to : undefined,
                         keywords: fm.title && fm.title.value ? fm.title.value : undefined
 
+                    //Hides the overlaid progress box if request failed
+                    }).takeUntil(this.ngUnsubscribe).catch(error => {
+                        agApi.hideOverlay();
+                        return Observable.throw(error);
+
                     //Once all submissions fetched, determines last row for display purposes.
-                    }).takeUntil(this.ngUnsubscribe).subscribe((rows) => {
+                    }).subscribe((rows) => {
                         let lastRow = -1;
 
+                        //Hides progress box.
                         agApi.hideOverlay();
 
                         //Removes any entries that are really revisions of sent submissions if showing temporary ones


### PR DESCRIPTION
- Changes the colour of the upload button's badge to red when an error occurs while uploading.
- Improves the styling and text for the "Progress" column in the event of failure.
- Widens the range of error objects accepted by the GlobalErrorHandler class to include plain strings. This paves the way for more meaningful errors from request failures.
- Detects if the there is no network at the global level, printing out a "please check"-type of error if not.
- Improves documentation and naming conventions.
