### PR TITLE
Clickwrap and UI fixes

### DIFF
--- a/src/app/auth/signup/signup.component.html
+++ b/src/app/auth/signup/signup.component.html
@@ -37,12 +37,11 @@
                             <span class="text-black">Email address</span>
                             <span *ngIf="email.invalid && email.touched">Please enter an email address</span>
                         </label>
-                        <input type="email" id="email" name="email" autofocus
+                        <input type="email" id="email" name="email" autocomplete="nope"
                                class="form-control"
                                [(ngModel)]="model.email"
                                (change)="resetGlobalError()"
                                #email="ngModel"
-                               #emailEl
                                required
                                validate-onblur>
                     </div>
@@ -102,9 +101,20 @@
                                     class="captcha-root"
                                     #recaptchaEl></re-captcha>
                     </div>
+                    <div [ngClass]="{'has-error': terms.invalid && terms.touched}">
+                        <div class="radio">
+                            <input type="checkbox" id="terms" name="terms"
+                                   [(ngModel)]="model.terms"
+                                   (change)="resetGlobalError()"
+                                   #terms="ngModel"
+                                   required
+                                   validate-onblur>
+                            I have read and agree to the Terms of Use and Privacy Notice, including the limited processing of personal data.
+                        </div>
+                    </div>
                     <div class="row-submit">
                         <button type="submit" class="btn btn-primary btn-submit"
-                                [disabled]="isLoading">Register</button>
+                                [disabled]="isLoading || terms.invalid">Register</button>
                         <div class="text-muted col-md-10">
                             <span *ngIf="isLoading"><i class="fa fa-cog fa-spin"></i> Registering...</span>
                         </div>

--- a/src/app/auth/signup/signup.component.ts
+++ b/src/app/auth/signup/signup.component.ts
@@ -24,7 +24,7 @@ export class SignUpComponent implements AfterViewInit {
     isLoading: boolean = false;
 
     model: RegistrationData = new RegistrationData();
-    error: ServerError = null;
+    error: ServerError = null;          //global object for showing error feedback
 
     @ViewChild('recaptchaEl')
     private recaptcha: RecaptchaComponent;
@@ -76,6 +76,9 @@ export class SignUpComponent implements AfterViewInit {
         }
     }
 
+    /**
+     * Resets the value of the error object to effectively hide feedback.
+     */
     resetGlobalError(): void {
         this.error = null;
     }

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.css
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.css
@@ -3,7 +3,7 @@
     margin-bottom: 10px;
     white-space: nowrap;
 }
-.cell {
+.cell:not(.canton) {
     float: none;
     display: inline-block;
     padding: 0 0.5vw;

--- a/src/styles/custom-layout.less
+++ b/src/styles/custom-layout.less
@@ -118,7 +118,7 @@ aside {
 .sidebar {
   overflow-y: auto;
   overflow-x: hidden;
-  z-index: calc(@zindex-navbar-fixed + 1);
+  z-index: @zindex-side-fixed;
 }
 
 .sidebar-offcanvas {
@@ -312,6 +312,14 @@ input[type="radio"] {
   outline: none !important;
 }
 
+//Corrects vertical mis-alignment of text besides checkboxes or radio buttons
+//Source: https://github.com/twbs/bootstrap/issues/16426
+input[type="radio"], input[type="checkbox"] {
+  margin-top: ((@line-height-base - 1)/2) * 1em;
+  width: 1em;
+  height: 1em;
+}
+
 //Optional fields (be them data or column ones) within features have discontinous outlines
 .optional .form-control {
   border-style: dashed;
@@ -400,7 +408,7 @@ input[type="radio"] {
 //Brings date picker's styles in line with the app's, removes pointer over inactive/disabled day cells
 //keeps the dialogue on top of all form elements and positions it with enough distance from any sidebar.
 .bs-datepicker {
-  z-index: calc(@zindex-navbar-fixed - 10);
+  z-index: @zindex-popover;
   margin-left: 35px;
   border-radius: 4px;
 }
@@ -446,3 +454,4 @@ input[type="radio"] {
   line-height: initial;
   pointer-events: auto
 }
+

--- a/src/styles/custom-navbar.less
+++ b/src/styles/custom-navbar.less
@@ -19,7 +19,7 @@
 @navbar-bsst-toggle-border-color:       #ddd;
 
 .navbar-bsst {
-  z-index: calc(@zindex-navbar-fixed + 2);   //apart from the top menu, the side menu and the subm-nav are also on top.
+  z-index: @zindex-header-fixed;   //apart from the top menu, the side menu and the subm-nav are also on top.
   background: @navbar-bsst-bg;
 
   .navbar-brand {

--- a/src/styles/custom-variables.less
+++ b/src/styles/custom-variables.less
@@ -275,6 +275,8 @@
 @zindex-popover:           1060;
 @zindex-tooltip:           1070;
 @zindex-navbar-fixed:      1030;
+@zindex-side-fixed:        1031;
+@zindex-header-fixed:      1032;
 @zindex-modal-background:  1040;
 @zindex-modal:             1050;
 


### PR DESCRIPTION
- Implements a clickwrap on the signup view in line with GDPR requirements .
- Fixes minor cross-browser issues with Firefox versions previous to v48:
  - Z-indexing is broken due to [calc's lack of support for unit-less numbers](https://bugzilla.mozilla.org/show_bug.cgi?id=594933). LESS constants are used instead.
  - Canton cell in grids appears dislodged. Left floating is preserved for them.
![fields displaced vertically on firefox 45 - dev](https://user-images.githubusercontent.com/6626603/41364215-f3c8ce98-6f2d-11e8-966c-4d92eedd33e4.png)

 