### PR TITLE
Minor changes to app's config surface.

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,8 +6,10 @@
   "APP_VERSION": "3.0",
   "APP_TABLET_BREAKPOINT": 993,
   "APP_ALLOW_PAST_DATES": true,
+  "APP_MAX_DATE_YEARS": 2,
   "APP_DATE_LIST_FORMAT": "dd MMM yyyy",
   "APP_DATE_INPUT_FORMAT": "DD MMM YYYY",
+  "APP_MAX_SUGGEST_LENGTH": 15,
   "MAX_CONCURRENT": 4,
   "GDPR_BANNER_URL": "https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/ebi-global-includes/script/5_ebiFrameworkNotificationBanner.js"
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -62,6 +62,23 @@ export class AppConfig {
     }
 
     /**
+     * Synonym getter providing the number of years ahead of the current date that the date picker will render
+     * selectable dates of.
+     * @returns {number} Maximum number of years into the future.
+     */
+    get maxDateYears(): number {
+        return this.config.APP_MAX_DATE_YEARS;
+    }
+
+    /**
+     * Synonym getter providing the maximum number of suggested entries in a typeahead box.
+     * @returns {number} Maximum length of the suggestion list.
+     */
+    get maxSuggestLength(): number {
+        return this.config.APP_MAX_SUGGEST_LENGTH;
+    }
+
+    /**
      * Synonym getter providing the URL for the script containing the GDPR banner's logic.
      * @returns {string} URL.
      */

--- a/src/app/shared/inline-edit.component.ts
+++ b/src/app/shared/inline-edit.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
+import {AppConfig} from "../app.config";
 
 @Component({
     selector: 'inline-edit',
@@ -25,7 +26,7 @@ export class InlineEditComponent implements ControlValueAccessor {
     @Input() placeholder?: string = '';         //indicative text inside the field if not in focus
     @Input() autosuggest: any[] = [];           //typeahead list of suggested values
     @Input() suggestThreshold: number = 0;      //the typeahead is meant to act as a reminder of other fields too
-    @Input() suggestLength: number = 30;        //max number of suggested values to be displayed at once
+    @Input() suggestLength: number;             //max number of suggested values to be displayed at once
     @Output() remove: EventEmitter<any> = new EventEmitter<any>();
 
     editing: boolean = false;
@@ -33,6 +34,14 @@ export class InlineEditComponent implements ControlValueAccessor {
     onTouched: any = () => {};
 
     private _value: string = '';
+
+    /**
+     * Sets the max number of suggestions shown at any given time.
+     * @param {AppConfig} appConfig - Global configuration object with app-wide settings.
+     */
+    constructor(private appConfig: AppConfig) {
+        this.suggestLength = appConfig.maxSuggestLength;
+    }
 
     get value(): any {
         return this._value;

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -28,7 +28,6 @@
                          [disableChange]="column.required || column.displayed"
                          [disableRemove]="!column.removable"
                          [autosuggest]="colNames"
-                         [suggestLength]="15"
                          [unique]="feature.uniqueCols"
                          validate-onblur>
             </inline-edit>
@@ -71,7 +70,6 @@
                                 [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
                                 [allowPast]="column.allowPast"
                                 [autosuggest]="column.values"
-                                [suggestLength]="15"
                                 (async)="addOnAsync($event, rowIdx)"
                                 validate-onblur>
                     </subm-field>

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -68,7 +68,6 @@
                                 [formControl]="featureForm.rowValueControl(0,column.id)"
                                 [allowPast]="column.allowPast"
                                 [autosuggest]="column.values"
-                                [suggestLength]="15"
                                 validate-onblur>
                     </subm-field>
                 </div>

--- a/src/app/submission/edit/subm-form/field/subm-field.component.html
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.html
@@ -32,7 +32,7 @@
         [required]="required"
         [readonly]="readonly"
         [allowPast]="allowPast"
-        [maxDate]="nowInNyears(2)"
+        [maxDate]="nowInNyears()"
         (focusout)="onBlur()">
 </date-input>
 

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/forms';
 import {FieldControl} from "../subm-form.service";
 import {TypeaheadMatch} from "ngx-bootstrap";
+import {AppConfig} from "../../../../app.config";
 
 
 @Component({
@@ -36,7 +37,7 @@ export class SubmFieldComponent implements ControlValueAccessor {
     @Input() formControl: FieldControl;         //reactive control associated with this field
     @Input() isSmall: boolean = true;           //flag for making the input area the same size as grid fields
     @Input() autosuggest: any[] = [];           //typeahead list of suggested values
-    @Input() suggestLength: number = 30;        //max number of suggested values to be displayed at once
+    @Input() suggestLength: number;             //max number of suggested values to be displayed at once
     @Input() suggestThreshold: number = 0;      //number of typed characters before suggestions are displayed.
                                                 //a value of 0 makes typeahead behave like an auto-suggest box.
 
@@ -44,7 +45,14 @@ export class SubmFieldComponent implements ControlValueAccessor {
     @ViewChild(NgModel)
     private inputModel: NgModel;
 
-    constructor(private rootEl: ElementRef) {}
+    /**
+     * Sets the max number of suggestions shown at any given time.
+     * @param {AppConfig} appConfig - Global configuration object with app-wide settings.
+     * @param {ElementRef} rootEl - Reference to the root element of the component's template.
+     */
+    constructor(private rootEl: ElementRef, private appConfig: AppConfig) {
+        this.suggestLength = appConfig.maxSuggestLength;
+    }
 
     get value() {
         return this._value;
@@ -143,7 +151,7 @@ export class SubmFieldComponent implements ControlValueAccessor {
      * @param {number} years - Number of years the date is incremented in.
      * @returns {Date} - Resulting date object.
      */
-    nowInNyears(years: number = 0): Date {
+    nowInNyears(years: number = this.appConfig.maxDateYears): Date {
         const currDate = new Date();
         return new Date(currDate.setFullYear(currDate.getFullYear() + years));
     }

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -49,7 +49,6 @@
                             [formControl]="get(field.id)"
                             [allowPast]="field.type.allowPast"
                             [autosuggest]="field.type.values"
-                            [suggestLength]="15"
                             [isSmall]="false"
                             validate-onblur>
                 </subm-field>

--- a/src/config.json
+++ b/src/config.json
@@ -6,8 +6,10 @@
   "APP_VERSION": "3.0",
   "APP_TABLET_BREAKPOINT": 993,
   "APP_ALLOW_PAST_DATES": true,
+  "APP_MAX_DATE_YEARS": 2,
   "APP_DATE_LIST_FORMAT": "dd MMM yyyy",
   "APP_DATE_INPUT_FORMAT": "DD MMM YYYY",
+  "APP_MAX_SUGGEST_LENGTH": 15,
   "MAX_CONCURRENT": 4,
   "GDPR_BANNER_URL": "https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/ebi-global-includes/script/5_ebiFrameworkNotificationBanner.js"
 }


### PR DESCRIPTION
Exposes two internal parameters as global constants: typeahead's suggestion length and datepicker's max number of years into the future.