### PR TITLE
NG 7 compliance and cached file list on submission edit

### DIFF
--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -22,7 +22,5 @@ export class AuthGuard implements CanActivate {
         } else {
             return true;
         }
-
-        //TODO this.authService.redirectUrl = state.url;
     }
 }

--- a/src/app/core/header/global-error.component.ts
+++ b/src/app/core/header/global-error.component.ts
@@ -18,7 +18,7 @@ export class GlobalErrorComponent {
      * Captures async errors and refreshes the UI (slides an alert in).
      * @param {ErrorHandler} geh - Global handler for errors.
      * @param {ChangeDetectorRef} changeRef - Forces change detection on this component.
-     * @param {ElementRef} rootEl - Reference to the root element of the component's template.
+     * @param {ElementRef} rootEl - Reference to the component's wrapping element
      */
     constructor (geh: ErrorHandler, changeRef: ChangeDetectorRef, private rootEl: ElementRef) {
         if (geh instanceof GlobalErrorHandler) {

--- a/src/app/file/file-list.component.ts
+++ b/src/app/file/file-list.component.ts
@@ -281,18 +281,22 @@ export class FileListComponent implements OnInit, OnDestroy {
                 this.gridOptions.api.hideOverlay();
                 return throwError(error);
 
-            }).subscribe(
-                data => {
-                    if (data.status === 'OK') { //use proper http codes for this!!!!!!
-                        this.path = p;
-                        this.updateDataRows([].concat(
-                            this.decorateUploads(this.fileUploadService.activeUploads()),
-                            this.decorateFiles(data.files)));
-                    } else {
-                        console.error("Error", data);
-                    }
+            }).subscribe(data => {
+                let decoratedRows;
+
+                if (data.status === 'OK') { //use proper http codes for this!!!!!!
+                    decoratedRows = [].concat(
+                        this.decorateUploads(this.fileUploadService.activeUploads()),
+                        this.decorateFiles(data.files)
+                    );
+
+                    this.path = p;
+                    this.updateDataRows(decoratedRows);
+                } else {
+                    console.error("Error", data);
                 }
-            );
+            }
+        );
     }
 
     updateDataRows(rows) {

--- a/src/app/file/file.service.ts
+++ b/src/app/file/file.service.ts
@@ -8,12 +8,28 @@ import 'rxjs/add/operator/catch';
 
 import * as _ from 'lodash';
 import {Subscription} from "rxjs/Subscription";
+import {Subject} from "rxjs/Rx";
 
 @Injectable()
 export class FileService {
     subscriptions: Subscription[] = [];
 
+    private cache: any = null;
+    private _whenFetched: Subject<any> = null;
+
     constructor(private http: HttpCustomClient) {}
+
+    /**
+     * Creates an observable normalised to resolve instantly if the list of files has already been retrieved.
+     * @returns {Observable<any>} Observable from subject.
+     */
+    get whenFetched(): Observable<any> {
+        if (this.cache) {
+            return Observable.of(this.cache);
+        } else {
+            return this._whenFetched.asObservable();
+        }
+    }
 
     getUserDirs(): Observable<any> {
         return this.getFiles('/Groups', 1, false)
@@ -22,8 +38,43 @@ export class FileService {
             .map(files => [].concat([{name: 'Home', path: '/User'}], files))
     }
 
-    getFiles(path: string = '/', depth: number = 1, showArchive: boolean = true): Observable<any> {
-        return this.http.get(`/api/files?showArchive=${showArchive}&depth=${depth}&path=${path}`);
+    /**
+     * Retrieves the attributes for all files under a certain path and with a specific level of folder nesting.
+     * The request can be cached, avoiding any subsequent ones unless the cache has been explicitly flushed.
+     * @param {string} path - Path which the files live under.
+     * @param {number} depth - Upper limit for the number of nested folders.
+     * @param {boolean} showArchive - If true, it includes compressed files.
+     * @param {boolean} isCached - If true, subsequent requests will draw on the cache for responses.
+     * @returns {Observable<any>} Observable the request has been turned into.
+     */
+    getFiles(path: string = '/', depth: number = 1, showArchive: boolean = true, isCached: boolean = false): Observable<any> {
+        const url = `/api/files?showArchive=${showArchive}&depth=${depth}&path=${path}`;
+
+        //Cached mode => First request for cached list of files
+        if (isCached) {
+            if (!this._whenFetched) {
+                this.http.get(url).subscribe(response => {
+                    this.cache = response;
+                    this._whenFetched.next(response);
+                    this._whenFetched.complete();
+                });
+                this._whenFetched = new Subject<any>();
+                return this.whenFetched;
+
+            //Cached mode after first request => Subsequent calls are prevented from making more requests
+            } else {
+                return this.whenFetched;
+            }
+
+        //Non-cached mode => issues an additional request as normal
+        } else {
+            return this.http.get(url);
+        }
+    }
+
+    flushCache() {
+        this._whenFetched = null;
+        this.cache = null;
     }
 
     removeFile(fullPath): Observable<any> {

--- a/src/app/shared/inline-edit.component.html
+++ b/src/app/shared/inline-edit.component.html
@@ -17,6 +17,7 @@
            (blur)="onEditBoxBlur($event)"
            (click)="canEdit && !disableChange && startEditing()"
            (keyup.enter)="onEditBoxEnter($event, ahead._container)"
+           (typeaheadOnSelect)="onSuggestSelect($event)"
            #ahead="bs-typeahead"
            #inlineEditBox/>
     <div *ngIf="!editing" class="icons">

--- a/src/app/shared/inline-edit.component.ts
+++ b/src/app/shared/inline-edit.component.ts
@@ -2,6 +2,7 @@ import {
     Component,
     Input,
     Output,
+    ElementRef,
     forwardRef,
     EventEmitter
 } from '@angular/core';
@@ -38,8 +39,9 @@ export class InlineEditComponent implements ControlValueAccessor {
     /**
      * Sets the max number of suggestions shown at any given time.
      * @param {AppConfig} appConfig - Global configuration object with app-wide settings.
+     * @param {ElementRef} rootEl - Reference to the component's wrapping element.
      */
-    constructor(private appConfig: AppConfig) {
+    constructor(private rootEl: ElementRef, private appConfig: AppConfig) {
         this.suggestLength = appConfig.maxSuggestLength;
     }
 
@@ -93,6 +95,17 @@ export class InlineEditComponent implements ControlValueAccessor {
             this.value = this.emptyValue;
         }
         this.stopEditing();
+    }
+
+    /**
+     * Handler for select event from auto-suggest typeahead. Fixes the lack of a change event when selecting
+     * a value without any character being typed (typically in combination with typeaheadMinLength = 0).
+     * The closest input element descendant will be the event's target.
+     * TODO: this might be sorted in newer versions of the ngx-bootstrap plugin. Duplicate events may occur due to the repeated calling of "set value(value)" above (cannot keep track of the last value and, by extension, can't detect change).
+     * @param selection - Object for the currently selected value.
+     */
+    onSuggestSelect(selection: any) {
+        this.rootEl.nativeElement.getElementsByTagName('input')[0].dispatchEvent(new Event('change', {bubbles: true}));
     }
 
     /**

--- a/src/app/submission-shared/date-input.component.ts
+++ b/src/app/submission-shared/date-input.component.ts
@@ -53,7 +53,7 @@ export class DateInputComponent implements ControlValueAccessor {
      * its default formats.
      * @param {BsDatepickerConfig} config - Configuration object for the datepicker directive.
      * @param {AppConfig} appConfig - Global configuration object with app-wide settings.
-     * @param {ElementRef} rootEl - Reference to the root element of the component's template.
+     * @param {ElementRef} rootEl - Reference to the component's wrapping element
      */
     constructor(config: BsDatepickerConfig, private appConfig: AppConfig, private rootEl: ElementRef) {
         config.showWeekNumbers = false;
@@ -147,10 +147,19 @@ export class DateInputComponent implements ControlValueAccessor {
      * @see {@link https://valor-software.com/ngx-bootstrap/#/datepicker}
      */
     onPickerSet(dateObj: Date, isChange: boolean = this.datepicker.isOpen) {
+        let formattedDate;          //date in format expected by backend
+
         if (dateObj && !isEqualDate(dateObj, this.dateValue)) {
             this.dateValue = dateObj;
-            this.onChange(formatDate(this.dateValue));
-            isChange && this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
+            formattedDate = formatDate(this.dateValue);
+            this.onChange(formattedDate);
+
+            //Propagates the date change through the DOM if so wished.
+            if (isChange) {
+                this.rootEl.nativeElement.value = formattedDate;
+                this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
+            }
+
         }
     }
 

--- a/src/app/submission-shared/file-input.component.ts
+++ b/src/app/submission-shared/file-input.component.ts
@@ -5,10 +5,8 @@ import {
 } from '@angular/core';
 
 import {
-    FormControl,
     ControlValueAccessor,
-    NG_VALUE_ACCESSOR,
-    NG_VALIDATORS
+    NG_VALUE_ACCESSOR
 } from '@angular/forms';
 
 import {FileService} from 'app/file/index';
@@ -55,7 +53,7 @@ export class FileInputComponent implements ControlValueAccessor {
      */
     ngOnInit() {
         this.fileService
-            .getFiles('/User')
+            .getFiles('/User', 1, true, true)
             .map(data => data.files)
             .map(files => files.map(f => f.path.replace(/^\/User\//, '')))
             .subscribe((files) => {
@@ -70,7 +68,8 @@ export class FileInputComponent implements ControlValueAccessor {
                 if (!this.isFound) {
                     this.value = '';
                 }
-            });
+            }
+        );
     }
 
     /**

--- a/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
+++ b/src/app/submission/direct-submit/direct-submit-sidebar.component.ts
@@ -254,7 +254,7 @@ export class DirectSubmitSideBarComponent implements OnInit {
      * Carries out the necessary requests for the selected files, detecting their format automatically.
      * NOTE: Requests are bundled into groups of MAX_CONCURRENT requests to avoid overwhelming the browser and/or
      * the server when dealing with a high number of files.
-     * @param {string} submType -
+     * @param {string} submType - Indicates whether the submitted file should create or update an existing database entry.
      */
     private onSubmit(submType: string): void {
         let nonClearedFiles;

--- a/src/app/submission/edit/subm-edit.component.ts
+++ b/src/app/submission/edit/subm-edit.component.ts
@@ -39,6 +39,7 @@ import {SubmValidationErrorsComponent} from "./subm-navbar/subm-validation-error
 import * as _ from "lodash";
 import {SubmSideBarComponent} from "./subm-sidebar/subm-sidebar.component";
 import {Subject} from "rxjs/Subject";
+import {FileService} from "../../file/file.service";
 
 @Component({
     selector: 'subm-edit',
@@ -82,7 +83,8 @@ export class SubmEditComponent implements OnInit {
                 private modalService: BsModalService,
                 private appConfig: AppConfig,
                 private userData: UserData,
-                private changeRef: ChangeDetectorRef) {
+                private changeRef: ChangeDetectorRef,
+                fileService: FileService) {
 
         //Initally collapses the sidebar for tablet-sized screens if applicable
         this.sideBarCollapsed = window.innerWidth < this.appConfig.tabletBreak;
@@ -91,6 +93,10 @@ export class SubmEditComponent implements OnInit {
         //NOTE: All calls are coalesced into the last one since it's that one that will lead to the most
         //up-to-date copy of the submission.
         this.onChange = _.throttle(this.onChange, 500, {'leading': false});
+
+        //Makes sure user files are fetched every time a submission is edited to ensure up-to-date file data for file inputs.
+        //TODO: File inputs are not passed in the list of files as of now. Ideally, the request should be done at the submission level, not the control level.
+        fileService.flushCache();
 
         this.ngUnsubscribe = new Subject<void>();
     }

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.html
@@ -21,9 +21,9 @@
                          containerClass="text-danger"
                          popover="{{featureForm.columnControl(column.id).invalid &&
                                     featureForm.columnControl(column.id).touched ? 'Please use a unique column name' : ''}}"
-                         [(ngModel)]="column.name"
                          emptyValue="{{'Column ' + (idx + 1)}}"
                          (remove)="feature.removeColumn(column.id)"
+                         (change)="onFieldChange(column, $event.target.value, 'name')"
                          [formControl]="featureForm.columnControl(column.id)"
                          [required]="column.required"
                          [disableEdit]="readonly || column.readonly || !userData.isPrivileged"
@@ -68,13 +68,13 @@
                                 popover="{{featureForm.rowValueControl(rowIdx, column.id).invalid &&
                                            featureForm.rowValueControl(rowIdx, column.id).touched ? featureForm.rowErrors[rowIdx][column.id] : ''}}"
                                 [type]="column.valueType"
-                                [(ngModel)]="row.valueFor(column.id).value"
                                 [readonly]="readonly || column.readonly"
                                 [required]="column.required"
                                 [formControl]="featureForm.rowValueControl(rowIdx, column.id)"
                                 [allowPast]="column.allowPast"
                                 [autosuggest]="column.values"
                                 (async)="addOnAsync($event, rowIdx)"
+                                (change)="onFieldChange(row.valueFor(column.id), $event.target.value)"
                                 validate-onblur>
                     </subm-field>
                 </div>

--- a/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-grid.component.ts
@@ -70,7 +70,8 @@ export class FeatureGridComponent implements AfterViewInit {
     addOnAsync(data: any, rowIdx: number) {
         const columns = this.feature.columns.slice(0);
         const attrNames = Object.keys(data);
-        const attributes = [];
+        const attributes = [];      //column attributes to be changed with their respective values
+        const formValues = {};      //formgroup version of the above
 
         //The first column is assumed to be the source of the async event and, therefore, does not require updating.
         columns.shift();
@@ -87,9 +88,25 @@ export class FeatureGridComponent implements AfterViewInit {
             }
         });
 
-        //Updates the row and notifies the outside world as a single change event.
+        //Updates the form controls corresponding to the fields of the affected row in the feature.
+        attributes.forEach(attribute => {
+            formValues[this.feature.firstId(attribute.name)] = attribute.value;
+        });
+        this.featureForm.patchRow(rowIdx, formValues);
+
+        //Updates the submission model's row and notifies the outside world as a single change event.
         this.feature.add(attributes, rowIdx);
         this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
+    }
+
+    /**
+     * Handler for the change event. Only save an attribute when its associated cell changes.
+     * @param {Object} attrObj - Object representative of the attribute.
+     * @param {string} newValue - New value for the specified attribute.
+     * @param {string} [attrName = 'value'] - Name of the attribute whose value is being saved.
+     */
+    onFieldChange(attrObj: any, newValue: string, attrName: string = 'value') {
+        attrObj[attrName] = newValue;
     }
 
     /**

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.html
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.html
@@ -32,7 +32,6 @@
                                containerClass="text-danger"
                                popover="{{featureForm.columnControl(column.id).invalid &&
                                           featureForm.columnControl(column.id).touched ? 'Please use a unique key name' : ''}}"
-                               [ngModel]="column.name"
                                [formControl]="featureForm.columnControl(column.id)"
                                [readonly]="isColUIReq(column) || column.displayed"
                                [typeahead]="isColUIReq(column) || column.displayed ? [] : colNames"
@@ -44,7 +43,7 @@
                                [unique]="feature.uniqueCols"
                                validate-onblur
                                (keyup.enter)="ahead._container ? $event.stopPropagation() : return"
-                               (change)="onColumnChange(column, $event.target.value)"
+                               (change)="onFieldChange(column, $event.target.value, 'name')"
                                (typeaheadOnSelect)="onSuggestSelect($event, column)"
                                (blur)="featureForm.columnControl(column.id).value ||
                                        featureForm.columnControl(column.id).setValue(feature.typeName + ' ' + (idx + 1))">
@@ -67,8 +66,8 @@
                                 containerClass="{{featureForm.feature.type.required ? 'text-danger' : 'text-warning'}}"
                                 popover="{{featureForm.rowValueControl(0, column.id).invalid &&
                                            featureForm.rowValueControl(0, column.id).touched ? featureForm.rowErrors[0][column.id] : ''}}"
+                                (change)="onFieldChange(feature.rows[0].valueFor(column.id), $event.target.value)"
                                 [type]="column.valueType"
-                                [(ngModel)]="feature.rows[0].valueFor(column.id).value"
                                 [readonly]="readonly || column.readonly"
                                 [required]="column.required"
                                 [formControl]="featureForm.rowValueControl(0,column.id)"

--- a/src/app/submission/edit/subm-form/feature/feature-list.component.ts
+++ b/src/app/submission/edit/subm-form/feature/feature-list.component.ts
@@ -42,12 +42,13 @@ export class FeatureListComponent implements AfterViewInit {
     }
 
     /**
-     * Handler for the change event. Only save a key's name when it has changed.
-     * @param {Attribute} column - Object representative of the current column.
-     * @param {string} newKey - New key name for the current column.
+     * Handler for the change event. Only save an attribute when its associated cell changes.
+     * @param {Object} attrObj - Object representative of the attribute.
+     * @param {string} newValue - New value for the specified attribute.
+     * @param {string} [attrName = 'value'] - Name of the attribute whose value is being saved.
      */
-    onColumnChange(column: Attribute, newKey: string) {
-        column.name = newKey;
+    onFieldChange(attrObj: any, newValue: string, attrName: string = 'value') {
+        attrObj[attrName] = newValue;
     }
 
     /**
@@ -60,7 +61,7 @@ export class FeatureListComponent implements AfterViewInit {
     onSuggestSelect(selection: TypeaheadMatch, column: Attribute) {
         if (column.name != selection.value) {
             this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
-            this.onColumnChange(column, selection.value);
+            this.onFieldChange(column, selection.value,'name');
         }
     }
 

--- a/src/app/submission/edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/edit/subm-form/field/subm-field.component.ts
@@ -2,7 +2,10 @@ import {
     Component,
     Input,
     forwardRef,
-    ElementRef, ViewChild, Output, EventEmitter
+    ElementRef,
+    ViewChild,
+    Output,
+    EventEmitter
 } from '@angular/core';
 
 import {
@@ -48,7 +51,7 @@ export class SubmFieldComponent implements ControlValueAccessor {
     /**
      * Sets the max number of suggestions shown at any given time.
      * @param {AppConfig} appConfig - Global configuration object with app-wide settings.
-     * @param {ElementRef} rootEl - Reference to the root element of the component's template.
+     * @param {ElementRef} rootEl - Reference to the component's wrapping element.
      */
     constructor(private rootEl: ElementRef, private appConfig: AppConfig) {
         this.suggestLength = appConfig.maxSuggestLength;
@@ -137,13 +140,14 @@ export class SubmFieldComponent implements ControlValueAccessor {
     }
 
     /**
-     * Handler for select event from auto-suggest typeahead. Fixes the lack of a change event when
-     * selecting a value without any character being typed (typically in combination with typeaheadMinLength = 0).
-     * TODO: this might be sorted in newer versions of the ngx-bootstrap plugin. Duplicate events may occur due to the repeated calling of set value() above (cannot keep track of the last value and, by extension, can't detect change).
+     * Handler for select event from auto-suggest typeahead. Fixes the lack of a change event when selecting
+     * a value without any character being typed (typically in combination with typeaheadMinLength = 0).
+     * The closest input element descendant will be the event's target.
+     * TODO: this might be sorted in newer versions of the ngx-bootstrap plugin. Duplicate events may occur due to the repeated calling of "set value(value)" above (cannot keep track of the last value and, by extension, can't detect change).
      * @param {TypeaheadMatch} selection - Object for the currently selected value.
      */
     onSuggestSelect(selection: TypeaheadMatch) {
-        this.rootEl.nativeElement.dispatchEvent(new Event('change', {bubbles: true}));
+        this.rootEl.nativeElement.getElementsByTagName('input')[0].dispatchEvent(new Event('change', {bubbles: true}));
     }
 
     /**

--- a/src/app/submission/edit/subm-form/subm-form.component.html
+++ b/src/app/submission/edit/subm-form/subm-form.component.html
@@ -45,11 +45,11 @@
                             [type]="field.valueType"
                             [readonly]="readonly || field.readonly"
                             [required]="field.type.required"
-                            [(ngModel)]="field.value"
                             [formControl]="get(field.id)"
                             [allowPast]="field.type.allowPast"
                             [autosuggest]="field.type.values"
                             [isSmall]="false"
+                            (change)="onFieldChange(field, $event.target.value)"
                             validate-onblur>
                 </subm-field>
             </div>

--- a/src/app/submission/edit/subm-form/subm-form.component.ts
+++ b/src/app/submission/edit/subm-form/subm-form.component.ts
@@ -60,4 +60,14 @@ export class SubmFormComponent implements OnChanges {
             return fieldControl;
         }
     }
+
+    /**
+     * Handler for the change event. Only save an attribute when its associated cell changes.
+     * @param {Object} attrObj - Object representative of the attribute.
+     * @param {string} newValue - New value for the specified attribute.
+     * @param {string} [attrName = 'value'] - Name of the attribute whose value is being saved.
+     */
+    onFieldChange(attrObj: any, newValue: string, attrName: string = 'value') {
+        attrObj[attrName] = newValue;
+    }
 }

--- a/src/app/submission/edit/subm-form/subm-form.service.ts
+++ b/src/app/submission/edit/subm-form/subm-form.service.ts
@@ -462,6 +462,15 @@ export class FeatureForm {
         this.subscriptions = [];
     }
 
+    /**
+     * Updates a given group of the form controls making up a certain row.
+     * @param {number} rowIdx - Index for the row to be changed.
+     * @param rowValues - New row values in object form.
+     */
+    patchRow(rowIdx: number, rowValues: any) {
+        this.rowsFormArray.controls[rowIdx].patchValue(rowValues);
+    }
+
     private get columnsFormGroup(): FormGroup {
         return <FormGroup>this.form.get('columns');
     }
@@ -520,6 +529,7 @@ export class FeatureForm {
         let colAttr;                    //attribute corresponding to the column under which this control will lie
         let control;
 
+        //TODO: follow a recipe similar to addFieldControl's to support other validators
         if (tmpl.required) {
             valueValidators.push(nonBlankVal());
         }

--- a/src/app/submission/shared/submission.model.ts
+++ b/src/app/submission/shared/submission.model.ts
@@ -418,6 +418,16 @@ export class Feature extends HasUpdates<UpdateEvent> {
     }
 
     /**
+     * ID of the first column with a matching name. For features with unique columns (eg: grids), it's a safe guess
+     * for any given attribute name.
+     * @param {string} name - Name of the column whose ID is to be retrieved.
+     * @returns {string} Attribute ID for the named column.
+     */
+    firstId(name: string): string {
+        return this._columns.allWithName(name)[0].id
+    }
+
+    /**
      * Determines the feature is made up of empty rows.
      * NOTE: This is equally applicable to lists as long as they are considered transposed grids, the
      * only row being the set of values for each key.

--- a/src/app/submission/shared/unique.directive.ts
+++ b/src/app/submission/shared/unique.directive.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/forms';
 
 @Directive({
-    selector: '[unique][ngModel]',
+    selector: '[unique]',
     host: {
         '(change)': 'onChange()'
     },


### PR DESCRIPTION
- Due to the [deprecation of edge-case mixed templates in Angular 7](https://next.angular.io/api/forms/FormControlName#use-with-ngmodel), it removes the ngModel directive wherever necessary, using the DOM change event to propagate new values to the submission model. This is a temporary solution until the disconnection between said model and the form controls –an architectural decision embedded into the codebase [very early on](https://github.com/EBIBioStudies/BioStudyUISub/commit/57ceb5463d5220e13a72b2cb43109e6e597b7743#diff-9f647c6cf0f4180c235ead5f7b38677cL23)– is removed. 
![screen shot 2018-08-01 at 16 57 44](https://user-images.githubusercontent.com/6626603/43721884-f18aaf9c-998b-11e8-8037-3ddd5a07cb46.png)

- Caches the first response for user files to avoid further requests every time a file input control is rendered within a file grid. This must be regarded as a temporary solution. In the longer term, the single request for user files should be initiated at the submission level, not from within an input control.
