### PR TITLE
Locally we need to start the application without SSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json --ssl true --ssl-key ssl/localhost.key --ssl-cert ssl/localhost.crt --progress",
+    "start-no-ssl": "ng serve --proxy-config proxy.conf.json --progress",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
There is a useful script that Jhan shared me to start app without SSL. It's better to keep the script available in the `package.json` so in the future anyone can use it. 