### PR TITLE
[165939281] Self-referencing direct upload issues

### DIFF
--- a/src/app/file/file-list/file-list.component.ts
+++ b/src/app/file/file-list/file-list.component.ts
@@ -1,13 +1,7 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
-
 import {ActivatedRoute, Params} from '@angular/router';
-
 import {GridOptions} from 'ag-grid-community/main';
-import {Observable, of, throwError} from 'rxjs';
-import 'rxjs/add/observable/of';
-
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/takeUntil';
+import {of, throwError} from 'rxjs';
 import {Subject} from 'rxjs/Subject';
 import {AppConfig} from '../../app.config';
 import {FileUpload, FileUploadList} from '../shared/file-upload-list.service';
@@ -17,15 +11,17 @@ import {FileActionsCellComponent} from './ag-grid/file-actions-cell.component';
 import {FileTypeCellComponent} from './ag-grid/file-type-cell.component';
 import {ProgressCellComponent} from './ag-grid/upload-progress-cell.component';
 import {UploadBadgeItem} from './file-upload-badge/file-upload-badge.component';
-import {filter, switchMap} from 'rxjs/operators';
+import {switchMap} from 'rxjs/operators';
 import {ModalService} from '../../shared/modal.service';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/takeUntil';
 
 @Component({
     selector: 'file-list',
     templateUrl: './file-list.component.html',
     styleUrls: ['./file-list.component.css']
 })
-
 export class FileListComponent implements OnInit, OnDestroy {
     protected ngUnsubscribe: Subject<void>;     // stopper for all subscriptions
     private rowData: any[];
@@ -178,19 +174,19 @@ export class FileListComponent implements OnInit, OnDestroy {
     }
 
     onUploadFilesSelect(files: FileList) {
-        const uploadedFiles = new Set(this.rowData.map( f => f.name));
-        const newFiles =  Array.from(files).map( f => f.name);
-        const overlap = newFiles.filter(name => uploadedFiles.has(name));
+        const uploadedFileNames = this.rowData.map((file) => file.name);
+        const filesToUpload =  Array.from(files).map((file) => file.name);
+        const overlap = filesToUpload.filter((fileToUpload) => uploadedFileNames.includes(fileToUpload));
 
         (overlap.length > 0 ? this.confirmOverwrite(overlap) : of(true))
             .takeUntil(this.ngUnsubscribe)
-            .subscribe( () => this.upload(files));
-
+            .subscribe(() => this.upload(files));
     }
 
     private confirmOverwrite(overlap) {
         const overlapString = overlap.length === 1 ? overlap[0] + '?' :
             overlap.length + ' files? (' + overlap.join(', ') + ')' ;
+
         return this.modalService.whenConfirmed(`Do you want to overwrite ${overlapString}`,
             'Overwrite files?', 'Overwrite');
     }
@@ -226,15 +222,16 @@ export class FileListComponent implements OnInit, OnDestroy {
             }
         }));
     }
+
     private removeFile(fileName: string): void {
         this.modalService.whenConfirmed(`Do you want to delete "${fileName}"?`, 'Delete a file', 'Delete')
             .pipe( switchMap( (it) => this.fileService.removeFile(this.path.absolutePath(fileName))))
             .takeUntil(this.ngUnsubscribe)
             .subscribe(it => this.loadData());
     }
+
     private removeUpload(u: FileUpload) {
         this.fileUploadList.remove(u);
         this.loadData();
     }
-
 }

--- a/src/app/file/shared/file-upload-list.service.ts
+++ b/src/app/file/shared/file-upload-list.service.ts
@@ -123,7 +123,7 @@ export class FileUploadList {
     }
 
     upload(path: Path, files: File[]): FileUpload {
-        let upload = new FileUpload(path, files, this.fileService);
+        const upload = new FileUpload(path, files, this.fileService);
 
         this.uploads.push(upload);
 

--- a/src/app/file/shared/file.service.ts
+++ b/src/app/file/shared/file.service.ts
@@ -32,7 +32,7 @@ export class FileService {
     }
 
     upload(fullPath: string, files: File[]): Observable<UploadEvent> {
-        let formData = new FormData();
+        const formData = new FormData();
 
         files.forEach(file => {
             formData.append('files', file, file.name)

--- a/src/app/file/shared/path.ts
+++ b/src/app/file/shared/path.ts
@@ -1,6 +1,11 @@
 export class Path {
-    constructor(private rootPath: string,
-                private relativePath: string) {
+    static join(...parts: string[]) {
+        return parts.join('/').replace(/\/[\/]+/, '/');
+    }
+
+    constructor(
+        private rootPath: string,
+        private relativePath: string) {
     }
 
     get root(): string {
@@ -28,9 +33,5 @@ export class Path {
 
     addRel(name: string): Path {
         return new Path(this.rootPath, Path.join(this.relativePath, name));
-    }
-
-    static join(...parts: string[]) {
-        return parts.join('/').replace(/\/[\/]+/, '/');
     }
 }

--- a/src/app/submission/submission-direct/direct-submit-file-upload.service.ts
+++ b/src/app/submission/submission-direct/direct-submit-file-upload.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { Observable } from "rxjs";
+import { FileService } from '../../file/shared/file.service';
+import { Path } from '../../file/shared/path';
+import { UploadEvent } from '../../file/shared/http-upload-client.service';
+
+@Injectable()
+export class DirectSubmitFileUploadService {
+  private fileService: FileService;
+  private path: Path = new Path('/User', '/');
+
+  constructor(fileService: FileService) {
+    this.fileService = fileService;
+  }
+
+  doUpload(file: File): Observable<UploadEvent> {
+    const absolutePath = this.path.absolutePath();
+    const uploadRequest = this.fileService.upload(absolutePath, [file]);
+
+    return uploadRequest;
+  }
+}

--- a/src/app/submission/submission-direct/direct-submit.service.ts
+++ b/src/app/submission/submission-direct/direct-submit.service.ts
@@ -141,21 +141,20 @@ export class DirectSubmitService {
 
     /**
      * Checks the overall status of the request queue by probing its members.
+     *
      * @param {string} statusName - Descriptive name of the status.
      * @returns {boolean} True if the queue is with the status checked.
      */
     isQueueStatus(statusName: string): boolean {
         let condition = 'some';
 
-        if (statusName == 'busy') {
+        if (statusName === 'busy') {
             statusName = 'inprogress';
-        } else if (statusName == 'successful' || statusName == 'done') {
+        } else if (statusName === 'successful' || statusName === 'done') {
             condition = 'every';
         }
 
-        return this._requests[condition](request => {
-            return request[statusName];
-        });
+        return this._requests[condition](request => request[statusName]);
     }
 
     /**
@@ -209,8 +208,8 @@ export class DirectSubmitService {
             catchError((error: any) => {
                 req.onResponse(error.message || 'unknown error', ReqStatus.ERROR);
 
-                //NOTE: an empty observable is used instead of throwing an exception to prevent this transaction
-                //cancelling any remaining ones.
+                // NOTE: an empty observable is used instead of throwing an exception to prevent this transaction
+                // cancelling any remaining ones.
                 return of(null);
             }));
     }

--- a/src/app/submission/submission-direct/submission-direct.module.ts
+++ b/src/app/submission/submission-direct/submission-direct.module.ts
@@ -1,11 +1,12 @@
-import {NgModule} from '@angular/core';
-import {RouterModule} from '@angular/router';
-import {SharedModule} from '../../shared/shared.module';
-import {SubmissionResultsModule} from '../submission-results/submission-results.module';
-import {SubmissionSharedModule} from '../submission-shared/submission-shared.module';
-import {DirectSubmitSideBarComponent} from './direct-submit-sidebar.component';
-import {DirectSubmitComponent} from './direct-submit.component';
-import {DirectSubmitService} from './direct-submit.service';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule } from '../../shared/shared.module';
+import { SubmissionResultsModule } from '../submission-results/submission-results.module';
+import { SubmissionSharedModule } from '../submission-shared/submission-shared.module';
+import { DirectSubmitSideBarComponent } from './direct-submit-sidebar.component';
+import { DirectSubmitComponent } from './direct-submit.component';
+import { DirectSubmitFileUploadService } from './direct-submit-file-upload.service';
+import { DirectSubmitService } from './direct-submit.service';
 
 @NgModule({
     imports: [
@@ -15,6 +16,7 @@ import {DirectSubmitService} from './direct-submit.service';
         SubmissionResultsModule
     ],
     providers: [
+        DirectSubmitFileUploadService,
         DirectSubmitService
     ],
     declarations: [

--- a/src/app/submission/submission-list/subm-list.component.ts
+++ b/src/app/submission/submission-list/subm-list.component.ts
@@ -174,7 +174,7 @@ export class SubmListComponent {
                 this.gridOptions!.api!.sizeColumnsToFit();
                 this.setDatasource();
 
-                window.onresize = () => this.gridOptions!.api!.sizeColumnsToFit();
+                window.onresize = () => this.gridOptions!.api! && this.gridOptions!.api!.sizeColumnsToFit();
             }
         };
 


### PR DESCRIPTION
When a user is direct uploading a submission, the system should upload the file before loading the submission. This will reduce the work a user has to do when submitting a file (excel) that contains metadata and data at the same time.