### PR TITLE
File description in EU-ToxRisk template should be optional

### DIFF
--- a/src/app/submission/submission-shared/model/templates/eutoxrisk.template.ts
+++ b/src/app/submission/submission-shared/model/templates/eutoxrisk.template.ts
@@ -351,7 +351,7 @@ export const EutoxriskTemplate = {
                     {
                         'name': 'Description',
                         'valueType': {'name': 'text'},
-                        'display': 'required'
+                        'display': 'desirable'
                     },
                     {
                         'name': 'Type',


### PR DESCRIPTION
After speaking with Ugis, he agreed to make the file description field optional in EU-ToxRisk template