### PR TITLE
Keep Org affiliation if the user provides a custom one through direct upload

### DIFF
--- a/src/app/submission/submission-shared/model/pagetab-to-submission.utils.ts
+++ b/src/app/submission/submission-shared/model/pagetab-to-submission.utils.ts
@@ -88,17 +88,19 @@ function pageTabSectionToSectionData(ptSection: PtSection, parentAttributes: PtA
         });
     }
 
-    const formattedSubSections = subsections
+    const formattedSections = subsections
         .filter(hasSubsections)
         .map((section) => pageTabSectionToSectionData(section));
+
+    const formattedSubSections = subsections.map((subSection) => pageTabSectionToSectionData(subSection));
 
     return <SectionData> {
         type: ptSection.type,
         accno: ptSection.accno,
         attributes: attributes,
         features: features,
-        sections: formattedSubSections,
-        subsections: subsections
+        sections: formattedSections,
+        subsections: formattedSubSections
     };
 }
 

--- a/src/app/submission/submission-shared/model/pagetab/pagetab-authors.utils.spec.ts
+++ b/src/app/submission/submission-shared/model/pagetab/pagetab-authors.utils.spec.ts
@@ -120,7 +120,7 @@ describe('AuthorsAndAffiliations:', () => {
                         },
                         {
                             name: 'Organisation',
-                            value: 'ORG1'
+                            value: 'Org1'
                         }
                     ]
                 },
@@ -154,7 +154,7 @@ describe('AuthorsAndAffiliations:', () => {
                             value: 'John D'
                         },
                         {
-                            name: 'Affiliation',
+                            name: 'affiliation',
                             isReference: true,
                             value: 'o1'
                         }
@@ -168,9 +168,9 @@ describe('AuthorsAndAffiliations:', () => {
                             value: 'Bob D'
                         },
                         {
-                            name: 'Affiliation',
+                            name: 'affiliation',
                             isReference: true,
-                            value: 'o1'
+                            value: 'o2'
                         }
                     ]
                 },
@@ -182,14 +182,14 @@ describe('AuthorsAndAffiliations:', () => {
                             value: 'Guy R'
                         },
                         {
-                            name: 'Affiliation',
+                            name: 'affiliation',
                             value: ''
                         }
                     ]
                 },
                 {
                     type: 'Organization',
-                    accno: 'o1',
+                    accno: 'o2',
                     attributes: [
                         {
                             name: 'Name',

--- a/src/app/submission/submission-shared/model/pagetab/pagetab-authors.utils.ts
+++ b/src/app/submission/submission-shared/model/pagetab/pagetab-authors.utils.ts
@@ -5,9 +5,9 @@ const isEqualTo = (value: string) => {
 };
 
 export function getOrganizationFromSubsection(section, orgName) {
-    const subsections = section.subsections || [];
+    const { sections = [] } = section.subsections || {};
 
-    return subsections.sections.find((sectionItem) => (
+    return sections.find((sectionItem) => (
         sectionItem.typeName === 'Organization' &&
         sectionItem.data.attributes.some((attribute) => attribute.value === orgName )
     )) || {};

--- a/src/app/submission/submission-shared/model/pagetab/pagetab.model.ts
+++ b/src/app/submission/submission-shared/model/pagetab/pagetab.model.ts
@@ -67,6 +67,7 @@ export interface PtNameAndValue {
 }
 
 export interface PtAttribute {
+    accno?: string;
     name?: string;
     value?: string;
     isReference?: boolean;

--- a/src/app/submission/submission-shared/model/submission-to-pagetab.utils.ts
+++ b/src/app/submission/submission-shared/model/submission-to-pagetab.utils.ts
@@ -1,16 +1,18 @@
 import {AttributeData, Feature, Section, Submission} from './submission';
 import {
     AttrExceptions,
-    contacts2Authors,
     LinksUtils,
-    mergeAttributes,
     PageTab,
     PtAttribute,
     PtFile,
     PtFileItem,
     PtLink,
     PtLinkItem,
-    PtSection
+    PtSection,
+    contacts2Authors,
+    getOrganizationFromSubsection,
+    mergeAttributes,
+    PtSectionItem
 } from './pagetab';
 import {DEFAULT_TEMPLATE_NAME, SubmissionType} from './templates';
 import {PAGE_TAG, Tag} from './model.common';
@@ -66,7 +68,7 @@ function section2PtSection(section: Section, isSanitise: boolean = false): PtSec
 }
 
 function withPageTag(tags: Tag[]): Tag[] {
-    if (tags.find(t => t.value == PAGE_TAG.value) !== undefined) {
+    if (tags.find(t => t.value === PAGE_TAG.value) !== undefined) {
         return tags;
     }
     return [...tags, ...[PAGE_TAG]];
@@ -81,9 +83,13 @@ function extractSectionAttributes(section: Section, isSanitise: boolean): PtAttr
 function extractSectionSubsections(section: Section, isSanitize: boolean): PtSection[] {
     const featureSections = contacts2Authors(
         section.features.list().filter(f => !isFileType(f.typeName) && !isLinkType(f.typeName) && !isLibraryFileType(f.typeName))
-            .map(f => extractFeatureAttributes(f, isSanitize)
-                .map(attrs => <PtSection>{type: f.typeName, attributes: attrs})
-            ).reduce((rv, el) => rv.concat(el), [])
+            .map(f => {
+                const featureAttributes = extractFeatureAttributes(f, isSanitize);
+
+                return featureAttributes.map(attrs => {
+                    return <PtSection>{type: f.typeName, attributes: attrs, subsections: <PtSectionItem> section.subsections };
+                });
+            }).reduce((rv, el) => rv.concat(el), [])
     );
 
     return featureSections.concat(section.sections.list().map(s => section2PtSection(s, isSanitize)));

--- a/src/app/submission/submission-shared/model/submission/submission.model.ts
+++ b/src/app/submission/submission-shared/model/submission/submission.model.ts
@@ -521,6 +521,7 @@ export class Section {
     readonly sections: Sections;
     readonly subsections: Sections;
     readonly tags: Tags;
+    readonly data: SectionData;
 
     constructor(type: SectionType, data: SectionData = <SectionData>{}, accno: string = '') {
         this.tags = Tags.create(data);
@@ -532,6 +533,7 @@ export class Section {
         this.annotations = Feature.create(type.annotationsType,
             (data.attributes || []).filter(a => a.name && type.getFieldType(a.name) === undefined)
         );
+        this.data = data;
         this.features = new Features(type, data.features);
         this.sections = new Sections(type, data.sections);
         this.subsections = new Sections(type, data.subsections);

--- a/src/app/submission/submission-shared/model/submission/submission.model.ts
+++ b/src/app/submission/submission-shared/model/submission/submission.model.ts
@@ -513,31 +513,28 @@ export class Fields {
 
 export class Section {
     private _accno: string;
-
     readonly id: string;
     readonly type: SectionType;
     readonly annotations: Feature;
     readonly fields: Fields;
     readonly features: Features;
     readonly sections: Sections;
+    readonly subsections: Sections;
     readonly tags: Tags;
 
     constructor(type: SectionType, data: SectionData = <SectionData>{}, accno: string = '') {
         this.tags = Tags.create(data);
-
         this.id = `section_${nextId()}`;
         this.type = type;
-
         this._accno = data.accno || accno;
-
         this.fields = new Fields(type, data.attributes);
-
         // Any attribute names from the server that do not match top-level field names are added as annotations.
         this.annotations = Feature.create(type.annotationsType,
             (data.attributes || []).filter(a => a.name && type.getFieldType(a.name) === undefined)
         );
         this.features = new Features(type, data.features);
         this.sections = new Sections(type, data.sections);
+        this.subsections = new Sections(type, data.subsections);
     }
 
     get accno(): string {
@@ -597,7 +594,8 @@ export class Sections {
         const definedTypes = type.sectionTypes.map(t => t.name);
         sections.filter(sd => sd.type === undefined || !definedTypes.includes(sd.type))
             .forEach(sd => {
-                this.add(type.getSectionType(sd.type || 'UnknownSectionType'), sd);
+                const accno = sd.accno;
+                this.add(type.getSectionType(sd.type || 'UnknownSectionType'), sd, accno);
             });
     }
 
@@ -718,16 +716,17 @@ export interface TaggedData {
 }
 
 export interface SectionData extends TaggedData {
-    type?: string;
     accno?: string;
     attributes?: AttributeData[];
     features?: FeatureData[];
     sections?: SectionData[];
+    subsections?: SectionData[];
+    type?: string;
 }
 
 export interface SubmissionData extends TaggedData {
     accno?: string;
     attributes?: AttributeData[];
-    section?: SectionData;
     isRevised?: boolean;
+    section?: SectionData;
 }


### PR DESCRIPTION
In some cases, the user upload an study with a custom name for Org affiliation, like this:

```
Name	         Julianna Kobolák
E-mail	         julianna.kobolak@biotalentum.hu
Role	     PI
<affiliation>	BIOT
```

```
Organization    BIOT
Name    BioTalentum Ltd
```

We were replacing the `BIOT` value in the example with an `o1`, `o2`, etc.

With this fix it keeps the same affiliation relation. 