### PR TITLE
Ensure keywords aren't extracted as attributes if they're empty

### DIFF
--- a/src/app/pages/submission/submission-edit/subm-sidebar/subm-sidebar.component.ts
+++ b/src/app/pages/submission/submission-edit/subm-sidebar/subm-sidebar.component.ts
@@ -29,16 +29,6 @@ export class SubmSidebarComponent implements OnDestroy {
   private unsubscribeForm = new Subject<void>();
 
   constructor(private submEditService: SubmEditService) {
-    this.submEditService.serverError$
-      .pipe(takeUntil(this.unsubscribe))
-      .subscribe((error) => {
-        if (error.log !== undefined) {
-          this.serverError = ServerError.fromResponse(error.log);
-        } else {
-          this.serverError = ServerError.fromResponse(error);
-        }
-      });
-
     this.submEditService.sectionSwitch$
       .pipe(takeUntil(this.unsubscribe))
       .subscribe(sectionForm => this.switchSection(sectionForm));

--- a/src/app/pages/submission/submission-shared/submission-to-pagetab.service.ts
+++ b/src/app/pages/submission/submission-shared/submission-to-pagetab.service.ts
@@ -95,10 +95,10 @@ export class SubmissionToPageTabService {
     let keywordsAsAttributes: PtAttribute[] = [];
 
     if (keywordsFeature !== undefined) {
-      const keywordFeature: PtAttribute[][] = this.extractFeatureAttributes(keywordsFeature, isSanitise);
+      const attributes: PtAttribute[][] = this.extractFeatureAttributes(keywordsFeature, isSanitise);
 
-      if (keywordFeature.length > 0) {
-        keywordsAsAttributes = keywordFeature.map((column) => <PtAttribute>column.pop());
+      if (attributes.length > 0) {
+        keywordsAsAttributes = attributes.map((column) => <PtAttribute>column.pop());
       }
     }
 

--- a/src/app/pages/submission/submission-shared/submission-to-pagetab.service.ts
+++ b/src/app/pages/submission/submission-shared/submission-to-pagetab.service.ts
@@ -41,16 +41,18 @@ export class SubmissionToPageTabService {
   }
 
   submissionToPageTab(subm: Submission, isSanitise: boolean = false): PageTab {
+    const sectionAttributes: PtAttribute[] =
+      this.extractSectionAttributes(subm.section, isSanitise).filter((at) => {
+        return AttrExceptions.editable.includes(at.name!);
+      });
+
     return <PageTab>{
       type: 'Submission',
       accno: subm.accno,
       section: this.sectionToPtSection(subm.section, isSanitise),
       tags: subm.tags.tags,
       accessTags: subm.tags.accessTags,
-      attributes: mergeAttributes(
-        subm.attributes.map(at => this.attributeDataToPtAttribute(at)),
-        this.extractSectionAttributes(subm.section, isSanitise)
-          .filter(at => AttrExceptions.editable.includes(at.name!)))
+      attributes: mergeAttributes(subm.attributes.map(at => this.attributeDataToPtAttribute(at)), sectionAttributes)
     };
   }
 
@@ -78,20 +80,32 @@ export class SubmissionToPageTabService {
   }
 
   private extractFeatureAttributes(feature: Feature, isSanitise: boolean): PtAttribute[][] {
-    return feature.rows.map(row =>
-      feature.columns.map(c => <PtAttribute>{ name: c.name, value: row.valueFor(c.id)!.value })
-        .filter(attr => (isSanitise && !isEmptyAttr(attr)) || !isSanitise));
+    const mappedFeatures: PtAttribute[][] = feature.rows.map((row) => {
+      const attributes: PtAttribute[] =
+        feature.columns.map((column) => <PtAttribute>{ name: column.name, value: row.valueFor(column.id)!.value });
+
+      return attributes.filter((attr) => (isSanitise && !isEmptyAttr(attr)) || !isSanitise);
+    });
+
+    return mappedFeatures.filter((mappedFeature) => mappedFeature.length > 0);
   }
 
   private extractSectionAttributes(section: Section, isSanitise: boolean): PtAttribute[] {
-    const keywordsFeature = section.features.list().find((feature) => feature.typeName === 'Keywords');
-    const keywordsAsAttributes = keywordsFeature ?
-      this.extractFeatureAttributes(keywordsFeature, isSanitise).map((keyword) => <PtAttribute>keyword.pop()) : [];
+    const keywordsFeature: Feature | undefined = section.features.list().find((feature) => feature.typeName === 'Keywords');
+    let keywordsAsAttributes: PtAttribute[] = [];
+
+    if (keywordsFeature !== undefined) {
+      const keywordFeature: PtAttribute[][] = this.extractFeatureAttributes(keywordsFeature, isSanitise);
+
+      if (keywordFeature.length > 0) {
+        keywordsAsAttributes = keywordFeature.map((column) => <PtAttribute>column.pop());
+      }
+    }
 
     return ([] as Array<PtAttribute>).concat(
       this.fieldsAsAttributes(section, isSanitise),
       (this.extractFeatureAttributes(section.annotations, isSanitise).pop() || []),
-      keywordsAsAttributes || []
+      keywordsAsAttributes
     );
   }
 

--- a/src/app/shared/server-error.handler.ts
+++ b/src/app/shared/server-error.handler.ts
@@ -27,11 +27,12 @@ export class ServerError {
     const { error } = response;
     const data = {
       message: 'Unknown error type', // Default error message
-      error: error.log
+      error: {}
     };
 
     if (error && error.log) {
       data.message = error.log.message;
+      data.error = error.log;
     }
 
     return new ServerError(response.status, error.status, data);


### PR DESCRIPTION
- Ensure keywords aren't extracted as attributes if they're empty
- Don't get error log if error is undefined
- Don't throw errors from sidebar as they're caught from submission edit service