### PR TITLE
Fix an issue validating DNA and Protein fields

### DIFF
--- a/src/app/pages/submission/submission-edit/shared/form-validators.ts
+++ b/src/app/pages/submission/submission-edit/shared/form-validators.ts
@@ -47,14 +47,15 @@ export class FormValidators {
   }
 
   static formatDna: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const value: { raw: string } = control.value;
-    const isEmpty: boolean = isNotDefinedOrEmpty(value.raw);
+    const value: string = control.value || '';
+    const [richValue, rawValue] = value.split('@');
+    const isEmpty: boolean = isNotDefinedOrEmpty(richValue);
 
     if (isEmpty) {
       return null;
     }
 
-    const isValueValid: boolean = isDnaSequenceValid(value.raw);
+    const isValueValid: boolean = isDnaSequenceValid(rawValue);
 
     return isValueValid ? null : { format: { value } };
   }
@@ -73,14 +74,15 @@ export class FormValidators {
   }
 
   static formatProtein: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const value: { raw: string } = control.value;
-    const isEmpty: boolean = isNotDefinedOrEmpty(value.raw);
+    const value: string = control.value || '';
+    const [richValue, rawValue] = value.split('@');
+    const isEmpty: boolean = isNotDefinedOrEmpty(richValue);
 
     if (isEmpty) {
       return null;
     }
 
-    const isValueValid: boolean = isProteinSequenceValid(value.raw);
+    const isValueValid: boolean = isProteinSequenceValid(rawValue);
 
     return isValueValid ? null : { format: { value } };
   }

--- a/src/app/pages/submission/submission-edit/shared/model/field-control.model.ts
+++ b/src/app/pages/submission/submission-edit/shared/model/field-control.model.ts
@@ -1,6 +1,6 @@
 import { ControlRef } from '../control-reference';
 import { CustomFormControl } from './custom-form-control.model';
-import { Field, FieldType } from '../../../submission-shared/model';
+import { Field, FieldType } from 'app/pages/submission/submission-shared/model';
 import { SubmFormValidators, ErrorMessages } from '../form-validators';
 
 export class FieldControl {

--- a/src/app/pages/submission/submission-edit/subm-form/field/subm-field.component.ts
+++ b/src/app/pages/submission/submission-edit/subm-form/field/subm-field.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { FieldType, ValueType, TextValueType } from 'app/pages/submission/submission-shared/model/templates';
 import { isStringEmpty } from 'app/utils';
-import { RichTextFieldValue } from './../../../submission-shared/model/submission/submission.model';
 import { FieldControl } from '../../shared/model/field-control.model';
 
 class ValueLength {
@@ -62,12 +61,6 @@ export class SubmFieldComponent {
   }
 
   get isEmpty(): boolean {
-    if (this.fieldType.valueType.isRich()) {
-      const fieldValue: RichTextFieldValue = this.fieldControl.control.value as RichTextFieldValue;
-
-      return isStringEmpty(fieldValue.raw);
-    }
-
     return isStringEmpty(this.fieldControl!.control.value as string);
   }
 

--- a/src/app/pages/submission/submission-shared/model/submission/submission.model.ts
+++ b/src/app/pages/submission/submission-shared/model/submission/submission.model.ts
@@ -19,11 +19,6 @@ export interface SubmissionSection {
   subsections: Sections
 }
 
-export interface RichTextFieldValue {
-  raw: string,
-  value: string
-}
-
 class Rows {
   private rows: Array<ValueMap> = [];
 
@@ -339,10 +334,9 @@ export class Field {
   readonly id: string;
   readonly type: FieldType;
 
-  private fieldValue: string | RichTextFieldValue;
+  private fieldValue: string;
 
-  constructor(type: FieldType,
-              value: RichTextFieldValue | string = '') {
+  constructor(type: FieldType, value: string = '') {
     this.id = `field_${nextId()}`;
     this.type = type;
     this.fieldValue = value;
@@ -360,11 +354,11 @@ export class Field {
     return this.type.displayType.isReadonly;
   }
 
-  get value(): string | RichTextFieldValue {
+  get value(): string {
     return this.fieldValue;
   }
 
-  set value(v: string | RichTextFieldValue) {
+  set value(v: string) {
     if (this.fieldValue !== v) {
       this.fieldValue = v;
     }

--- a/src/app/pages/submission/submission-shared/model/submission/submission.validator.ts
+++ b/src/app/pages/submission/submission-shared/model/submission/submission.validator.ts
@@ -1,4 +1,4 @@
-import { Feature, Field, Section, Submission, RichTextFieldValue } from './submission.model';
+import { Feature, Field, Section, Submission } from './submission.model';
 import { parseDate } from 'app/utils';
 import { FeatureType, SectionType, TextValueType, ValueType, ValueTypeName } from '../templates';
 
@@ -61,18 +61,8 @@ class ValidationRules {
   }
 
   static forField(field: Field): ValidationRule[] {
-    if (field.valueType.isRich()) {
-      const richTextValue: RichTextFieldValue  = field.value as RichTextFieldValue;
-      const rawValue: string = richTextValue.raw;
-
-      return [
-        ValidationRules.requiredValue(rawValue, field.name, field.type.displayType.isRequired),
-        ValidationRules.formattedValue(rawValue, field.valueType, field.name),
-        ...ValidationRules.forValue(rawValue, field.name, field.valueType)
-      ];
-    }
-
     const value: string = field.value as string;
+
     return [
       ValidationRules.requiredValue(value, field.name, field.type.displayType.isRequired),
       ValidationRules.formattedValue(value, field.valueType, field.name),

--- a/src/app/pages/submission/submission-shared/submission-to-pagetab.service.ts
+++ b/src/app/pages/submission/submission-shared/submission-to-pagetab.service.ts
@@ -1,4 +1,3 @@
-import { RichTextFieldValue } from './model/submission/submission.model';
 import { PAGE_TAG, Tag } from './model/model.common';
 import {
   AttrExceptions,
@@ -181,11 +180,12 @@ export class SubmissionToPageTabService {
   private fieldsAsAttributes(section: Section, isSanitise: boolean): any[] {
     return section.fields.list().map((field) => {
       if (field.valueType.isRich()) {
-        const fieldValue: RichTextFieldValue = field.value as RichTextFieldValue;
+        const fieldValue: string = field.value || '';
+        const [richValue] = fieldValue.split('@');
 
         return {
           name: field.name,
-          value: fieldValue.value,
+          value: richValue,
           valqual: [{name: 'display', value: 'html'}]
         } as PtAttribute;
       }

--- a/src/app/shared/dna-input/dna-input.component.ts
+++ b/src/app/shared/dna-input/dna-input.component.ts
@@ -3,6 +3,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ChangeEvent } from '@ckeditor/ckeditor5-angular';
 import * as DecoupledEditor from '@biostudies/ckeditor5-build-balloon';
 import viewToPlainText from '@ckeditor/ckeditor5-clipboard/src/utils/viewtoplaintext';
+import { isStringEmpty } from 'app/utils';
 
 const dnaColorScheme = [
   {
@@ -48,13 +49,13 @@ export class DNAInputComponent implements ControlValueAccessor {
   onEditorChange({ editor }: ChangeEvent): void {
     setTimeout(() => {
       this.dnaRawSequence = viewToPlainText(editor.editing.view.document.getRoot());
-      this.onChange({ value: this.dnaSequence, raw: this.dnaRawSequence });
+      this.informChange();
     }, 10);
   }
 
   onEditorReady(editor): void {
     this.dnaRawSequence = viewToPlainText(editor.editing.view.document.getRoot());
-    this.onChange({ value: this.dnaSequence, raw: this.dnaRawSequence });
+    this.informChange();
   }
 
   registerOnChange(fn: any): void {
@@ -73,6 +74,14 @@ export class DNAInputComponent implements ControlValueAccessor {
         this.dnaRawSequence = raw;
         this.dnaSequence = value;
       }
+    }
+  }
+
+  private informChange(): void {
+    if (!isStringEmpty(this.dnaSequence)) {
+      this.onChange(`${this.dnaSequence}@${this.dnaRawSequence}`);
+    } else {
+      this.onChange();
     }
   }
 

--- a/src/app/shared/protein-input/protein-input.component.ts
+++ b/src/app/shared/protein-input/protein-input.component.ts
@@ -3,6 +3,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ChangeEvent } from '@ckeditor/ckeditor5-angular';
 import * as DecoupledEditor from '@biostudies/ckeditor5-build-balloon';
 import viewToPlainText from '@ckeditor/ckeditor5-clipboard/src/utils/viewtoplaintext';
+import { isStringEmpty } from 'app/utils';
 
 @Component({
   selector: 'st-protein-input',
@@ -26,13 +27,13 @@ export class ProteinInputComponent implements ControlValueAccessor {
   onEditorChange({ editor }: ChangeEvent): void {
     setTimeout(() => {
       this.proteinRawSequence = viewToPlainText(editor.editing.view.document.getRoot());
-      this.onChange({ value: this.proteinSequence, raw: this.proteinRawSequence });
+      this.informChange();
     }, 10);
   }
 
   onEditorReady(editor): void {
     this.proteinRawSequence = viewToPlainText(editor.editing.view.document.getRoot());
-    this.onChange({ value: this.proteinSequence, raw: this.proteinRawSequence });
+    this.informChange();
   }
 
   registerOnChange(fn: any): void {
@@ -51,6 +52,14 @@ export class ProteinInputComponent implements ControlValueAccessor {
         this.proteinRawSequence = raw;
         this.proteinSequence = value;
       }
+    }
+  }
+
+  private informChange(): void {
+    if (!isStringEmpty(this.proteinSequence)) {
+      this.onChange(`${this.proteinSequence}@${this.proteinRawSequence}`);
+    } else {
+      this.onChange();
     }
   }
 


### PR DESCRIPTION
`ControlValueAccessor` doesn't support complex values for `onChange` function, it expects a `string` to trigger built in validations such as `Validations.required`. For DNA and Protein it was sending an object losing such built in validations.