### PR TITLE
Remove upload action types from direct upload page

### DIFF
--- a/src/app/pages/submission/submission-direct/direct-submit-file.component.html
+++ b/src/app/pages/submission/submission-direct/direct-submit-file.component.html
@@ -7,10 +7,8 @@
     <div class="card-body">
       <div class="card-title d-flex align-items-center">
         <div>
-          <i class="fa fa-2x" *ngIf="!hasSubmitPassed" aria-hidden="true" [ngClass]="{
-                'st-panel-description-icon': submitType != 'none',
-                'fa-plus': !isPending && submitType == 'create',
-                'fa-sync-alt': !isPending && submitType == 'update',
+          <i class="fa fa-2x st-panel-description-icon" *ngIf="!hasSubmitPassed" aria-hidden="true" [ngClass]="{
+                'fa-plus': !isPending,
                 'fa-caret-square-down text-danger': hasSubmitFailed,
                 'fa-edit': hasSubmitPassed,
                 'fa-exchange-alt': isSubmitting}">

--- a/src/app/pages/submission/submission-direct/direct-submit-file.component.ts
+++ b/src/app/pages/submission/submission-direct/direct-submit-file.component.ts
@@ -20,7 +20,6 @@ export class DirectSubmitFileComponent {
   @Input() isSubmitting;
   @Input() project;
   @Input() releaseDate;
-  @Input() submitType = 'none';
 
   handleOnFileClick(event: Event, hasSubmitFailed: boolean, accno: string): void {
     this.fileClick.emit({ event, hasSubmitFailed, accno });

--- a/src/app/pages/submission/submission-direct/direct-submit-sidebar.component.html
+++ b/src/app/pages/submission/submission-direct/direct-submit-sidebar.component.html
@@ -44,26 +44,9 @@
         </div>
       </ng-container>
     </div>
-    <div class="form-group">
-      <div class="border-bottom mb-2">
-        <label class="m-0">3. Upload mode</label>
-      </div>
-      <div>
-        <label>
-          <input type="radio" class="project-radio" name="submitType" value="create" [(ngModel)]="submitType">
-          Create new studies
-        </label>
-      </div>
-      <div>
-        <label>
-          <input type="radio" class="project-radio" name="submitType" value="update" [(ngModel)]="submitType">
-          Update studies
-        </label>
-      </div>
-    </div>
     <div class="btn-group">
       <button id="single-button" type="button" [disabled]="isProjFetch || isStatus('busy')"
-        (click)="onSubmit(submitType)" class="btn btn-primary btn-submit">
+        (click)="onSubmit()" class="btn btn-primary btn-submit">
         Upload
       </button>
     </div>
@@ -76,8 +59,7 @@
       </div>
     </div>
     <h4 class="text-white mt-2" *ngIf="!collapsed">
-      {{submitType == 'create' ? 'Creating' : 'Updating'}}
-      {{selectedFileCount > 1 ? 'studies' : 'study'}}...
+      Uploading {{selectedFileCount > 1 ? 'studies' : 'study'}}...
     </h4>
     <button class="btn btn-danger btn-sm mt-2" tooltip="Stop all pending uploads" placement="bottom" container="body"
       (click)="onCancelPending($event)">

--- a/src/app/pages/submission/submission-direct/direct-submit.component.html
+++ b/src/app/pages/submission/submission-direct/direct-submit.component.html
@@ -33,7 +33,7 @@
       <div class="content p-3 bg-light">
         <div class="card">
           <div *ngIf="!sidebar.hasRequests" class="card-body">
-            <h4>New direct {{sidebar.submitType == 'create' ? 'entry' : 'update'}}</h4>
+            <h4>New direct entry</h4>
             <p>Please fill in the form on the left-hand side to upload your studies:</p>
             <ol>
               <li>
@@ -67,36 +67,34 @@
           </div>
           <div *ngIf="sidebar.hasRequests" class="card-body">
             <ng-container *ngIf="sidebar.isStatus('busy')">
-              <h4>{{sidebar.submitType == 'create' ? 'Creating' : 'Updating'}} {{pluralise('study')}}...</h4>
-              <p>Please wait while the {{pluralise('studies')}} {{pluralise('is')}} being {{sidebar.submitType + 'd'}}
-                and
-                validated. Any invalid ones will be highlighted below. Click on them to reveal more details.</p>
+              <h4>Uploading {{pluralise('study')}}...</h4>
+              <p>Please wait while the {{pluralise('studies')}} {{pluralise('is')}} being sent
+                and validated. Any invalid ones will be highlighted below. Click on them to reveal more details.</p>
             </ng-container>
             <ng-container *ngIf="sidebar.isStatus('failed') && sidebar.isStatus('done')">
-              <h4>Error while {{sidebar.submitType == 'create' ? 'creating' : 'updating'}}
-                {{pluralise('study')}}</h4>
+              <h4>Error while uploading {{pluralise('study')}}</h4>
               <p>The {{pluralise('study')}} highlighted below {{pluralise('is')}} invalid or an unexpected
                 error was encountered. Please try to correct any issues before uploading the affected
                 {{pluralise('files')}} again. To show the error log, simply click on the relevant failed file.
               </p>
             </ng-container>
             <ng-container *ngIf="sidebar.isStatus('successful')">
-              <h4>{{pluralise('Study')}} {{sidebar.submitType + 'd'}}</h4>
+              <h4>{{pluralise('Study')}} uploaded</h4>
               <p>
                 The {{pluralise('study')}} specified below with accession {{pluralise('number')}}
                 <span *ngFor="let file of sidebar.model.files; let i = index; let last = last">
                   <strong>{{getAccno(i)}}</strong>{{last ? '' : ', '}}
                 </span>
-                {{pluralise('has')}} been successfully
-                {{sidebar.submitType == 'create' ? 'added to the BioStudies database' : 'updated'}}.
-                {{sidebar.selectedFileCount > 1 ? 'They' : 'It'}}
-                {{sidebar.submitType == 'create' ? 'will be available in the next 24 hours' : 'is available'}}
-                at the following {{pluralise('address')}}:
-                <span *ngFor="let file of sidebar.model.files; let i = index; let last = last">
-                  <a target="_blank" href="{{location.origin}}/biostudies/studies/{{getAccno(i)}}">
-                    {{location.hostname}}/biostudies/studies/{{getAccno(i)}}</a>{{last ? '' : ', '}}
-                </span>.
+                {{pluralise('has')}} been successfully uploaded to the BioStudies database. <br />
+                New studies or changes to existing studies will be available in the next 24 hours
+                at the following addresses:
               </p>
+              <ul>
+                <li *ngFor="let file of sidebar.model.files; let i = index;">
+                  <a target="_blank" href="{{location.origin}}/biostudies/studies/{{getAccno(i)}}">
+                    {{location.hostname}}/biostudies/studies/{{getAccno(i)}}</a>
+                </li>
+              </ul>
               <strong>
                 <a target="_blank" href="https://www.ebi.ac.uk/biostudies/about.html">
                   Citing my {{pluralise('study')}}
@@ -118,7 +116,7 @@
                 </a>
               </strong>
               <p>Sarkans U, Gostev M, Athar A, et al. <a href="http://doi.org/10.1093/nar/gkx965">The BioStudies
-                database-one stop shop for all data supporting a life sciences study.</a>
+                database-one stop shop for all data supporting a life sciences study. </a>
                 <i>Nucleic Acids Res.</i> 2018;46(D1):D1266-D1270. doi:10.1093/nar/gkx965
               </p>
             </ng-container>
@@ -130,7 +128,7 @@
             <st-direct-submit-file class="h-100" [accno]="getAccno(i)" [errorLog]="getLog(i)" [error]="getError(i)"
               [file]="file" [fileName]="file.name" [hasSubmitFailed]="isFail(i)" [hasSubmitPassed]="isSuccess(i)"
               [isPending]="isPending()" [isSubmitting]="isBusy(i)" [project]="sidebar.selectedProject"
-              [releaseDate]="getRelease(i)" [submitType]="sidebar.submitType" [isStudy]="file.isStudy"
+              [releaseDate]="getRelease(i)" [isStudy]="file.isStudy"
               (fileClick)="handleFileCardClick($event)" (isStudyChange)="handleIsStudyChange($event)">
             </st-direct-submit-file>
           </ng-container>

--- a/src/app/pages/submission/submission-direct/direct-submit.service.ts
+++ b/src/app/pages/submission/submission-direct/direct-submit.service.ts
@@ -9,11 +9,6 @@ enum ReqStatus {
   SUCCESS
 }
 
-enum ReqType {
-  CREATE,
-  UPDATE
-}
-
 export class DirectSubmitRequest {
   private directSubmissionAccno: string = '';
   private directSubmissionCreated: Date;
@@ -22,12 +17,10 @@ export class DirectSubmitRequest {
   private directSubmissionProject: string;
   private directSubmissionReleaseDate: string | undefined;
   private directSubmissionStatus: ReqStatus;
-  private directSubmissionType: ReqType;
 
-  constructor(filename: string, project: string, type: ReqType) {
+  constructor(filename: string, project: string) {
     this.directSubmissionFilename = filename;
     this.directSubmissionProject = project;
-    this.directSubmissionType = type;
 
     this.directSubmissionCreated = new Date();
     this.directSubmissionStatus = ReqStatus.SUBMIT;
@@ -63,10 +56,6 @@ export class DirectSubmitRequest {
 
   get project(): string {
     return this.directSubmissionProject;
-  }
-
-  get type(): ReqType {
-    return this.directSubmissionType;
   }
 
   get log(): any {
@@ -160,8 +149,8 @@ export class DirectSubmitService {
    * @param type - Indicates whether the submitted file should create or update an existing database entry.
    * @returns Stream of inputs coming from the subsequent responses.
    */
-  addRequest(file: File, project: string, type: string): Observable<any> {
-    const req = new DirectSubmitRequest(file.name, project, ReqType[type.toUpperCase()]);
+  addRequest(file: File, project: string): Observable<any> {
+    const req = new DirectSubmitRequest(file.name, project);
     const index = this.requests.length;
 
     this.requests.push(req);


### PR DESCRIPTION
- Remove the submit types from the direct upload page.
- The backend already detects whether the study is new or already exists by querying the accNo in the direct upload file.