### PR TITLE
Add support for field title

### DIFF
--- a/src/app/submission/submission-edit/shared/control-reference.ts
+++ b/src/app/submission/submission-edit/shared/control-reference.ts
@@ -8,8 +8,13 @@ export class ControlRef {
     readonly id: string,
     readonly name: string = '',
     readonly parentRef?: ControlGroupRef,
-    readonly icon: string = 'fa-square'
+    readonly icon: string = 'fa-square',
+    readonly title: string = ''
   ) {}
+
+  get displayName(): string {
+    return this.title || this.name;
+  }
 
   get parentName(): string {
     return this.parentRef ? this.parentRef.name : '';
@@ -73,16 +78,16 @@ export class ControlGroupRef {
   }
 
   fieldRef(field: Field): ControlRef {
-    return this.createRef(field.id, field.name, field.type.icon);
+    return this.createRef(field.id, field.name, field.type.icon, field.title);
   }
 
   rowValueRef(column: Attribute, rowId: string): ControlRef {
     return this.createRef(column.id + '#' + rowId, column.name);
   }
 
-  private createRef(id: string, name: string, icon?: string): ControlRef {
+  private createRef(id: string, name: string, icon?: string, title?: string): ControlRef {
     const parentName = this.tableName || this.sectionName;
     const uniqueId = [parentName, id].join('_');
-    return new ControlRef(uniqueId, name, this, icon || this.icon);
+    return new ControlRef(uniqueId, name, this, icon || this.icon, title);
   }
 }

--- a/src/app/submission/submission-edit/subm-form/field/subm-field.component.ts
+++ b/src/app/submission/submission-edit/subm-form/field/subm-field.component.ts
@@ -40,7 +40,7 @@ export class SubmFieldComponent {
   }
 
   get fieldName(): string {
-    return this.fieldControl.name;
+    return this.fieldType.title || this.fieldControl.name;
   }
 
   get valueType(): ValueType {

--- a/src/app/submission/submission-edit/subm-sidebar/subm-check-sidebar/subm-check-sidebar.component.html
+++ b/src/app/submission/submission-edit/subm-sidebar/subm-check-sidebar/subm-check-sidebar.component.html
@@ -28,7 +28,7 @@
       class="list-group-item list-group-item-action d-flex justify-content-between align-items-center bg-transparent text-white border-0">
       <div class="text-truncate pr-2">
         <i class="entry-item fas {{control.ref.icon}}"></i>
-        {{!collapsed ? '&nbsp;' + control.ref.name + '&nbsp;' : ''}}
+        {{!collapsed ? '&nbsp;' + control.ref.displayName + '&nbsp;' : ''}}
       </div>
       <span *ngIf="!collapsed" class="badge badge-danger"
         tooltip="{{collapsed ? '&quot;' + control.ref.name + '&quot; field is ' + tipText(control.errors) : 'Highlight field on the form'}}"

--- a/src/app/submission/submission-edit/subm-sidebar/subm-edit-sidebar/subm-edit-sidebar.component.ts
+++ b/src/app/submission/submission-edit/subm-sidebar/subm-edit-sidebar/subm-edit-sidebar.component.ts
@@ -1,7 +1,6 @@
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { Component, Input, OnDestroy } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { Option } from 'fp-ts/lib/Option';
 import { Subject, Subscription } from 'rxjs';
 import { UserData } from 'app/auth/shared';
 import { takeUntil } from 'rxjs/operators';
@@ -49,7 +48,7 @@ class DataTypeControl {
   }
 
   get prettyName(): string {
-    return this.type.name.replace(/([a-z])([A-Z])/g, '$1 $2');
+    return this.type.title || this.type.name.replace(/([a-z])([A-Z])/g, '$1 $2');
   }
 
   reset(): void {

--- a/src/app/submission/submission-shared/model/submission/submission.model.ts
+++ b/src/app/submission/submission-shared/model/submission/submission.model.ts
@@ -365,6 +365,10 @@ export class Field {
     return this.type.name;
   }
 
+  get title(): string {
+    return this.type.title;
+  }
+
   get valueType(): ValueType {
     return this.type.valueType;
   }

--- a/src/app/submission/submission-shared/model/templates/arrayexpress.template.ts
+++ b/src/app/submission/submission-shared/model/templates/arrayexpress.template.ts
@@ -18,6 +18,7 @@ export const arrayExpressTemplate = {
       },
       {
         name: 'ReleaseDate',
+        title: 'Release Date',
         icon: 'fa-calendar-alt',
         display: 'required',
         valueType: {
@@ -104,7 +105,6 @@ export const arrayExpressTemplate = {
       {
         name: 'Publication',
         display: 'optional',
-        title: 'Add Publications',
         description:
           'Add the bibliography relevant to the study. Autofill is available when searching by ' +
           '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed</a> identifier. ' +

--- a/src/app/submission/submission-shared/model/templates/bia.template.ts
+++ b/src/app/submission/submission-shared/model/templates/bia.template.ts
@@ -19,6 +19,7 @@ export const biaTemplate = {
       },
       {
         name: 'ReleaseDate',
+        title: 'Release Date',
         icon: 'fa-calendar-alt',
         display: 'required',
         valueType: {
@@ -120,7 +121,6 @@ export const biaTemplate = {
     tableTypes: [
       {
         name: 'Keywords',
-        title: 'Add Keywords',
         icon: 'fa-address-card',
         description: 'Add keywords',
         uniqueCols: true,
@@ -135,7 +135,6 @@ export const biaTemplate = {
       },
       {
         name: 'Contact',
-        title: 'Add Contacts',
         icon: 'fa-address-card',
         description: 'Add the contact details for the authors involved in the study.',
         uniqueCols: true,
@@ -279,7 +278,6 @@ export const biaTemplate = {
         description: 'Add the protocols involved in the study.',
         icon: 'fa-address-card',
         name: 'Study Protocols',
-        title: 'Study Protocols',
         uniqueCols: true,
         columnTypes: [
           {
@@ -311,7 +309,6 @@ export const biaTemplate = {
       },
       {
         name: 'Link',
-        title: 'Add Links',
         description:
           'Provide pointers to data held in external databases or to related information on the web. ' +
           'Compact URIs from <a target="_blank" href="https://www.ebi.ac.uk/miriam/main/collections">Identifiers.org</a> ' +
@@ -334,7 +331,6 @@ export const biaTemplate = {
       },
       {
         name: 'Publication',
-        title: 'Add Publications',
         description:
           'Add the bibliography relevant to the study. Autofill is available when searching by ' +
           '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed</a> identifier. For other IDs, you ' +
@@ -505,7 +501,6 @@ export const biaTemplate = {
           },
           {
             name: 'Other data files',
-            title: 'Add other data files',
             description: 'List other data files for the imaging study',
             icon: 'fa-file',
             uniqueCols: true,
@@ -533,7 +528,6 @@ export const biaTemplate = {
           },
           {
             name: 'Protocols',
-            title: 'Protocols',
             icon: 'fa-address-card',
             description: 'Add the protocols used in this study component.',
             uniqueCols: true,

--- a/src/app/submission/submission-shared/model/templates/default.template.ts
+++ b/src/app/submission/submission-shared/model/templates/default.template.ts
@@ -19,6 +19,7 @@ export const defaultTemplate = {
       },
       {
         name: 'ReleaseDate',
+        title: 'Release Date',
         icon: 'fa-calendar-alt',
         display: 'required',
         valueType: {
@@ -135,7 +136,6 @@ export const defaultTemplate = {
     tableTypes: [
       {
         name: 'Contact',
-        title: 'Add Contacts',
         description: 'Add the contact details for the authors involved in the study.',
         icon: 'fa-address-card',
         display: 'required',
@@ -250,7 +250,6 @@ export const defaultTemplate = {
       },
       {
         name: 'Link',
-        title: 'Add Links',
         description:
           'Provide pointers to data held in external databases or to related information on the web. ' +
           'Compact URIs from <a target="_blank" href="https://www.ebi.ac.uk/miriam/main/collections">Identifiers.org</a> ' +
@@ -273,7 +272,6 @@ export const defaultTemplate = {
       },
       {
         name: 'File',
-        title: 'Add Files',
         description: 'List the data files for the study and describe their respective scopes.',
         icon: 'fa-file',
         uniqueCols: true,
@@ -298,7 +296,6 @@ export const defaultTemplate = {
       },
       {
         name: 'Publication',
-        title: 'Add Publications',
         description:
           'Add the bibliography relevant to the study. Autofill is available when searching by ' +
           '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed</a> identifier. ' +

--- a/src/app/submission/submission-shared/model/templates/eutoxrisk.template.ts
+++ b/src/app/submission/submission-shared/model/templates/eutoxrisk.template.ts
@@ -102,7 +102,6 @@ export const euToxRiskTemplate = {
       }
     ],
     annotationsType: {
-      title: 'Describe your study',
       icon: 'fa-tag',
       description: 'Provide any additional details that may help discover or interpret the study.',
       columnTypes: [
@@ -124,7 +123,6 @@ export const euToxRiskTemplate = {
     tableTypes: [
       {
         name: 'Contact',
-        title: 'Add Contacts',
         icon: 'fa-address-card',
         description: 'Add the contact details for the authors involved in the study.',
         uniqueCols: true,
@@ -208,7 +206,6 @@ export const euToxRiskTemplate = {
       },
       {
         name: 'Endpoint',
-        title: 'Add endpoints',
         icon: 'fa-medkit',
         description: "Provide at least the method and analytical measure of the study's endpoints.",
         uniqueCols: true,
@@ -235,7 +232,6 @@ export const euToxRiskTemplate = {
       },
       {
         name: 'Compound',
-        title: 'Add compounds',
         icon: 'fa-flask',
         description:
           'List all parent compounds by their most common chemical name. ' +
@@ -295,7 +291,6 @@ export const euToxRiskTemplate = {
       },
       {
         name: 'Link',
-        title: 'Add Links',
         description:
           'Provide pointers to data held in external databases or to related information on the web. ' +
           'Compact URIs from <a target="_blank" href="https://www.ebi.ac.uk/miriam/main/collections">Identifiers.org</a> ' +
@@ -317,7 +312,6 @@ export const euToxRiskTemplate = {
       },
       {
         name: 'File',
-        title: 'Add Files',
         description: 'List the data files for the study and describe their respective scopes.',
         icon: 'fa-file',
         uniqueCols: true,
@@ -341,7 +335,6 @@ export const euToxRiskTemplate = {
       },
       {
         name: 'Publication',
-        title: 'Add Publications',
         description:
           'Add the bibliography relevant to the study. Autofill is available when searching by ' +
           '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed</a> identifier. ' +

--- a/src/app/submission/submission-shared/model/templates/hecatos.template.ts
+++ b/src/app/submission/submission-shared/model/templates/hecatos.template.ts
@@ -157,7 +157,6 @@ export const hecatosTemplate = {
       }
     ],
     annotationsType: {
-      title: 'Describe your study',
       icon: 'fa-tag',
       description: 'Provide any additional details that may help discover or interpret the study.',
       columnTypes: [
@@ -222,7 +221,6 @@ export const hecatosTemplate = {
     tableTypes: [
       {
         name: 'Contact',
-        title: 'Add Contacts',
         icon: 'fa-address-card',
         description: 'Add the contact details for the authors involved in the study.',
         uniqueCols: true,
@@ -291,7 +289,6 @@ export const hecatosTemplate = {
       },
       {
         name: 'Link',
-        title: 'Add Links',
         description:
           'Add the bibliography relevant to the study. Autofill is available when searching by ' +
           '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed</a> identifier. ' +
@@ -314,7 +311,6 @@ export const hecatosTemplate = {
       },
       {
         name: 'File',
-        title: 'Add Files',
         description: 'List the data files for the study and describe their respective scopes.',
         icon: 'fa-file',
         uniqueCols: true,
@@ -348,7 +344,6 @@ export const hecatosTemplate = {
       },
       {
         name: 'Publication',
-        title: 'Add Publications',
         description:
           'Add the bibliography relevant to the study. Autofill is available when searching by ' +
           '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed</a> identifier. For other IDs, you ' +
@@ -402,7 +397,6 @@ export const hecatosTemplate = {
       },
       {
         name: 'ProtocolName',
-        title: 'Add protocols',
         description: 'List the details of any experimental protocols employed.',
         icon: 'fa-cogs',
         uniqueCols: true,

--- a/src/app/submission/submission-shared/model/templates/proteindesigns.template.ts
+++ b/src/app/submission/submission-shared/model/templates/proteindesigns.template.ts
@@ -17,7 +17,8 @@ export const proteinDesignsTemplate = {
         }
       },
       {
-        name: 'Release Date',
+        name: 'ReleaseDate',
+        title: 'Release Date',
         icon: 'fa-calendar-alt',
         display: 'required',
         valueType: {
@@ -140,7 +141,6 @@ export const proteinDesignsTemplate = {
     tableTypes: [
       {
         name: 'SolutionCharacterization',
-        title: 'Solution characterization (structure) / Circular Dichroism (CD)',
         description: 'Solution characterization (structure) / Circular Dichroism (CD)',
         icon: 'fa-book',
         display: 'desirable',
@@ -160,7 +160,6 @@ export const proteinDesignsTemplate = {
       },
       {
         name: 'SolutionCharacterizationFluorescence',
-        title: 'Solution characterisation (structure) / fluorescence',
         description: 'Solution characterisation (structure) / fluorescence',
         icon: 'fa-book',
         display: 'desirable',
@@ -180,7 +179,6 @@ export const proteinDesignsTemplate = {
       },
       {
         name: 'File',
-        title: '',
         description: '3D structural confirmation of the design (Format supported by PDB)',
         icon: 'fa-file',
         display: 'desirable',
@@ -195,7 +193,6 @@ export const proteinDesignsTemplate = {
       },
       {
         name: 'Contact',
-        title: 'Add Contacts',
         description: 'Add the contact details for the authors involved in the study.',
         icon: 'fa-address-card',
         display: 'required',

--- a/src/app/submission/submission-shared/model/templates/submission-type.model.ts
+++ b/src/app/submission/submission-shared/model/templates/submission-type.model.ts
@@ -69,7 +69,8 @@ export abstract class TypeBase {
   constructor(
     public typeName: string,
     readonly tmplBased: boolean,
-    private scope: TypeScope<TypeBase> = GLOBAL_TYPE_SCOPE
+    private scope: TypeScope<TypeBase> = GLOBAL_TYPE_SCOPE,
+    public typeTitle?: string
   ) {
     this.typeName = isStringDefined(typeName) ? typeName.trim() : '';
 
@@ -82,6 +83,10 @@ export abstract class TypeBase {
     }
 
     scope.set(this.typeName, this);
+  }
+
+  get title(): string {
+    return this.typeTitle || '';
   }
 
   get name(): string {
@@ -247,9 +252,10 @@ export class FieldType extends TypeBase {
     name: string,
     data: Partial<FieldType> = {},
     scope?: TypeScope<TypeBase>,
-    parentDisplayType: DisplayType = DisplayType.OPTIONAL
+    parentDisplayType: DisplayType = DisplayType.OPTIONAL,
+    title?: string
   ) {
-    super(name, true, scope);
+    super(name, true, scope, title);
 
     this.valueType = ValueTypeFactory.create(data.valueType || {});
     this.icon = data.icon || 'fa-pencil-square-o';
@@ -268,7 +274,6 @@ export class TableType extends TypeBase {
   readonly displayType: DisplayType;
   readonly icon: string;
   readonly singleRow: boolean;
-  readonly title: string;
   readonly uniqueCols: boolean;
   readonly allowImport: boolean;
 
@@ -284,7 +289,6 @@ export class TableType extends TypeBase {
     super(name, isTemplBased, scope);
 
     data = data || {};
-    this.title = data.title || 'Add ' + this.name;
     this.description = data.description || '';
     this.singleRow = data.singleRow === true;
     this.uniqueCols = data.uniqueCols === true;
@@ -417,7 +421,7 @@ export class SectionType extends TypeBase {
     this.sectionExample = data.sectionExample || '';
 
     (data.fieldTypes || []).forEach(
-      (fieldType) => new FieldType(fieldType.name, fieldType, this.fieldScope, this.displayType)
+      (fieldType) => new FieldType(fieldType.name, fieldType, this.fieldScope, this.displayType, fieldType.title)
     );
     (data.tableTypes || []).forEach(
       (tableType) => new TableType(tableType.name, tableType, this.tableScope, isTemplBased, this.displayType)


### PR DESCRIPTION
Before it was using the `name` as title so if the name was composed of two or more words it was shown together. Release date is an example, it was displayed as `ReleaseDate` and with this change it should be displayed as `Release Date`.